### PR TITLE
Add optional `ADMIN_ADDRESS` to reusable workflows

### DIFF
--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -37,6 +37,8 @@ on:
       GH_TOKEN:
         description: 'GitHub token for pushing commits (defaults to GITHUB_TOKEN)'
         required: false
+      ADMIN_ADDRESS:
+        required: false
 
 jobs:
   read-config:
@@ -81,6 +83,7 @@ jobs:
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           RPC_URL: ${{ secrets.RPC_URL }}
+          ADMIN_ADDRESS: ${{ secrets.ADMIN_ADDRESS }}
         run: |
           # Ensure PRIVATE_KEY has 0x prefix
           if [[ "$PRIVATE_KEY" != 0x* ]]; then

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -26,6 +26,8 @@ on:
         required: true
       RPC_URL:
         required: true
+      ADMIN_ADDRESS:
+        required: false
 
 jobs:
   deploy-testnet:
@@ -55,6 +57,7 @@ jobs:
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           RPC_URL: ${{ secrets.RPC_URL }}
+          ADMIN_ADDRESS: ${{ secrets.ADMIN_ADDRESS }}
         run: |
           # Ensure PRIVATE_KEY has 0x prefix
           if [[ "$PRIVATE_KEY" != 0x* ]]; then

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -69,6 +69,9 @@ on:
       GH_TOKEN:
         description: 'GitHub token for pushing commits'
         required: false
+      ADMIN_ADDRESS:
+        description: 'Admin address for contract initialization'
+        required: false
 
 jobs:
   ci:
@@ -159,6 +162,7 @@ jobs:
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           RPC_URL: ${{ secrets.RPC_URL }}
+          ADMIN_ADDRESS: ${{ secrets.ADMIN_ADDRESS }}
         run: |
           if [[ "$PRIVATE_KEY" != 0x* ]]; then
             export PRIVATE_KEY="0x$PRIVATE_KEY"
@@ -259,6 +263,7 @@ jobs:
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           RPC_URL: ${{ secrets.RPC_URL }}
+          ADMIN_ADDRESS: ${{ secrets.ADMIN_ADDRESS }}
         run: |
           if [[ "$PRIVATE_KEY" != 0x* ]]; then
             export PRIVATE_KEY="0x$PRIVATE_KEY"


### PR DESCRIPTION
This PR extends the etherform reusable GitHub Actions workflows to support an optional `ADMIN_ADDRESS` secret, allowing downstream repos to supply the admin address required by upgradeable contract deployment scripts (via `vm.envAddress("ADMIN_ADDRESS")`).