### PR TITLE
feat: Etherform workflow improvements

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -5,6 +5,10 @@ name: CI (Reusable)
 on:
   workflow_call:
     inputs:
+      deployment-foundry-profile:
+        description: 'Foundry profile to use for deployment (must be defined in foundry.toml)'
+        type: string
+        default: ''
       check-formatting:
         description: 'Run forge fmt --check'
         type: boolean
@@ -18,6 +22,8 @@ jobs:
   check:
     name: Build & Test
     runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -128,24 +128,33 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
-            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
 
             # Build constructor args if present
             CONSTRUCTOR_ARGS_FLAG=""
-            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+
+            # Check if arguments exist in the transaction
+            if echo "$tx" | jq -e '.arguments | length > 0' >/dev/null 2>&1; then
               # Get constructor signature from compiled contract ABI
-              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+              ABI_JSON=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null) || true
 
-              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
-                # Convert JSON array to space-separated args for cast
-                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
-                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+              if [[ -n "$ABI_JSON" ]] && echo "$ABI_JSON" | jq -e '.' >/dev/null 2>&1; then
+                CONSTRUCTOR_SIG=$(echo "$ABI_JSON" | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
 
-                if [[ -n "$ENCODED_ARGS" ]]; then
-                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
-                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                  # Build args array for cast - each arg needs to be passed separately
+                  ENCODED_ARGS=""
+                  mapfile -t ARGS_ARRAY < <(echo "$tx" | jq -r '.arguments[]')
+
+                  if [[ ${#ARGS_ARRAY[@]} -gt 0 ]]; then
+                    ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" "${ARGS_ARRAY[@]}" 2>/dev/null) || true
+                  fi
+
+                  if [[ -n "$ENCODED_ARGS" ]]; then
+                    CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                    echo "  Constructor args encoded: $ENCODED_ARGS"
+                  fi
                 fi
               fi
             fi

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -119,7 +119,6 @@ jobs:
         if: matrix.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ matrix.blockscout_url }}
-          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -129,8 +128,27 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
+            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+
+            # Build constructor args if present
+            CONSTRUCTOR_ARGS_FLAG=""
+            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+              # Get constructor signature from compiled contract ABI
+              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+
+              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                # Convert JSON array to space-separated args for cast
+                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
+                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+
+                if [[ -n "$ENCODED_ARGS" ]]; then
+                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                fi
+              fi
+            fi
 
             # Retry up to 3 times with exponential backoff
             VERIFIED=false
@@ -138,8 +156,7 @@ jobs:
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
-                --rpc-url "$RPC_URL" \
-                --guess-constructor-args \
+                $CONSTRUCTOR_ARGS_FLAG \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
                 VERIFIED=true

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -121,15 +121,18 @@ jobs:
           BLOCKSCOUT_URL: ${{ matrix.blockscout_url }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
+          VERIFICATION_FAILED=false
 
           # Extract and verify each deployed contract with retry logic
-          jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE" | while read -r tx; do
+          # Use process substitution to avoid subshell issues with variable tracking
+          while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
 
             # Retry up to 3 times with exponential backoff
+            VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
@@ -137,17 +140,26 @@ jobs:
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
+                VERIFIED=true
                 break
               else
                 if [[ $attempt -lt 3 ]]; then
                   echo "Attempt $attempt failed, retrying in $((attempt * 30))s..."
                   sleep $((attempt * 30))
-                else
-                  echo "⚠ Verification pending for $CONTRACT_NAME after 3 attempts"
                 fi
               fi
             done
-          done
+
+            if [[ "$VERIFIED" == "false" ]]; then
+              echo "✗ Failed to verify $CONTRACT_NAME after 3 attempts"
+              VERIFICATION_FAILED=true
+            fi
+          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+
+          if [[ "$VERIFICATION_FAILED" == "true" ]]; then
+            echo "::error::One or more contracts failed verification"
+            exit 1
+          fi
 
       - name: Save deployment artifacts
         run: |

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -119,6 +119,7 @@ jobs:
         if: matrix.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ matrix.blockscout_url }}
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -137,6 +138,7 @@ jobs:
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
+                --rpc-url "$RPC_URL" \
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -116,6 +116,7 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
+        if: matrix.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ matrix.blockscout_url }}
         run: |

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -5,6 +5,10 @@ name: Deploy Mainnet (Reusable)
 on:
   workflow_call:
     inputs:
+      deployment-foundry-profile:
+        description: 'Foundry profile to use for deployment (must be defined in foundry.toml)'
+        type: string
+        default: ''
       deploy-script:
         description: 'Path to deployment script'
         type: string
@@ -68,6 +72,8 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.read-config.outputs.matrix) }}
     environment: ${{ matrix.environment }}
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -177,6 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy]
     if: success() && inputs.flatten-contracts
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -117,24 +117,33 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
-            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
 
             # Build constructor args if present
             CONSTRUCTOR_ARGS_FLAG=""
-            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+
+            # Check if arguments exist in the transaction
+            if echo "$tx" | jq -e '.arguments | length > 0' >/dev/null 2>&1; then
               # Get constructor signature from compiled contract ABI
-              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+              ABI_JSON=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null) || true
 
-              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
-                # Convert JSON array to space-separated args for cast
-                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
-                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+              if [[ -n "$ABI_JSON" ]] && echo "$ABI_JSON" | jq -e '.' >/dev/null 2>&1; then
+                CONSTRUCTOR_SIG=$(echo "$ABI_JSON" | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
 
-                if [[ -n "$ENCODED_ARGS" ]]; then
-                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
-                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                  # Build args array for cast - each arg needs to be passed separately
+                  ENCODED_ARGS=""
+                  mapfile -t ARGS_ARRAY < <(echo "$tx" | jq -r '.arguments[]')
+
+                  if [[ ${#ARGS_ARRAY[@]} -gt 0 ]]; then
+                    ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" "${ARGS_ARRAY[@]}" 2>/dev/null) || true
+                  fi
+
+                  if [[ -n "$ENCODED_ARGS" ]]; then
+                    CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                    echo "  Constructor args encoded: $ENCODED_ARGS"
+                  fi
                 fi
               fi
             fi

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -32,14 +32,37 @@ on:
         required: true
 
 jobs:
-  deploy-testnet:
-    name: Deploy to Testnet
+  read-config:
+    name: Read Network Config
     runs-on: ubuntu-latest
-    env:
-      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     outputs:
       network_name: ${{ steps.network.outputs.network_name }}
       blockscout_url: ${{ steps.network.outputs.blockscout_url }}
+      environment: ${{ steps.network.outputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read network config
+        id: network
+        run: |
+          BLOCKSCOUT_URL=$(jq -r '.testnets[${{ inputs.network-index }}].blockscout_url' ${{ inputs.network-config-path }})
+          NETWORK_NAME=$(jq -r '.testnets[${{ inputs.network-index }}].name' ${{ inputs.network-config-path }})
+          ENVIRONMENT=$(jq -r '.testnets[${{ inputs.network-index }}].environment' ${{ inputs.network-config-path }})
+          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
+          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+
+  deploy-testnet:
+    name: Deploy to Testnet
+    runs-on: ubuntu-latest
+    needs: [read-config]
+    environment: ${{ needs.read-config.outputs.environment }}
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
+    outputs:
+      network_name: ${{ needs.read-config.outputs.network_name }}
+      blockscout_url: ${{ needs.read-config.outputs.blockscout_url }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,14 +71,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Read network config
-        id: network
-        run: |
-          BLOCKSCOUT_URL=$(jq -r '.testnets[${{ inputs.network-index }}].blockscout_url' ${{ inputs.network-config-path }})
-          NETWORK_NAME=$(jq -r '.testnets[${{ inputs.network-index }}].name' ${{ inputs.network-config-path }})
-          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
-          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
 
       - name: Deploy contracts
         env:
@@ -90,9 +105,9 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
-        if: steps.network.outputs.blockscout_url != ''
+        if: needs.read-config.outputs.blockscout_url != ''
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.read-config.outputs.blockscout_url }}
           RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
@@ -140,22 +155,22 @@ jobs:
 
       - name: Save deployment artifacts
         run: |
-          mkdir -p deployments/${{ steps.network.outputs.network_name }}
+          mkdir -p deployments/${{ needs.read-config.outputs.network_name }}
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
 
           # Extract contracts with proper sourcePathAndName format
           jq '{contracts: [.transactions[] | select(.transactionType == "CREATE") | {sourcePathAndName: "src/\(.contractName).sol:\(.contractName)", address: .contractAddress}]}' "$BROADCAST_FILE" \
-            > deployments/${{ steps.network.outputs.network_name }}/deployment.json
+            > deployments/${{ needs.read-config.outputs.network_name }}/deployment.json
 
       - name: Upload deployment artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: deployment-${{ steps.network.outputs.network_name }}
+          name: deployment-${{ needs.read-config.outputs.network_name }}
           path: deployments/
 
       - name: Create deployment summary
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.read-config.outputs.blockscout_url }}
         run: |
           echo "## Testnet Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -90,6 +90,7 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
+        if: steps.network.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
         run: |

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -95,9 +95,11 @@ jobs:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
+          VERIFICATION_FAILED=false
 
           # Extract and verify each deployed contract with retry logic
-          jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE" | while read -r tx; do
+          # Use process substitution to avoid subshell issues with variable tracking
+          while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
 
@@ -105,6 +107,7 @@ jobs:
 
             # Retry up to 3 times with exponential backoff
             # Use --guess-constructor-args to auto-detect from on-chain bytecode
+            VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
@@ -112,17 +115,26 @@ jobs:
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
+                VERIFIED=true
                 break
               else
                 if [[ $attempt -lt 3 ]]; then
                   echo "Attempt $attempt failed, retrying in $((attempt * 30))s..."
                   sleep $((attempt * 30))
-                else
-                  echo "⚠ Verification pending for $CONTRACT_NAME after 3 attempts"
                 fi
               fi
             done
-          done
+
+            if [[ "$VERIFIED" == "false" ]]; then
+              echo "✗ Failed to verify $CONTRACT_NAME after 3 attempts"
+              VERIFICATION_FAILED=true
+            fi
+          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+
+          if [[ "$VERIFICATION_FAILED" == "true" ]]; then
+            echo "::error::One or more contracts failed verification"
+            exit 1
+          fi
 
       - name: Save deployment artifacts
         run: |

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -93,6 +93,7 @@ jobs:
         if: steps.network.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -112,6 +113,7 @@ jobs:
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
+                --rpc-url "$RPC_URL" \
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -108,7 +108,6 @@ jobs:
         if: needs.read-config.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ needs.read-config.outputs.blockscout_url }}
-          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -118,18 +117,35 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
+            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
 
+            # Build constructor args if present
+            CONSTRUCTOR_ARGS_FLAG=""
+            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+              # Get constructor signature from compiled contract ABI
+              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+
+              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                # Convert JSON array to space-separated args for cast
+                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
+                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+
+                if [[ -n "$ENCODED_ARGS" ]]; then
+                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                fi
+              fi
+            fi
+
             # Retry up to 3 times with exponential backoff
-            # Use --guess-constructor-args to auto-detect from on-chain bytecode
             VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
-                --rpc-url "$RPC_URL" \
-                --guess-constructor-args \
+                $CONSTRUCTOR_ARGS_FLAG \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
                 VERIFIED=true

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -5,6 +5,10 @@ name: Deploy Testnet (Reusable)
 on:
   workflow_call:
     inputs:
+      deployment-foundry-profile:
+        description: 'Foundry profile to use for deployment (must be defined in foundry.toml)'
+        type: string
+        default: ''
       deploy-script:
         description: 'Path to deployment script'
         type: string
@@ -31,6 +35,8 @@ jobs:
   deploy-testnet:
     name: Deploy to Testnet
     runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     outputs:
       network_name: ${{ steps.network.outputs.network_name }}
       blockscout_url: ${{ steps.network.outputs.blockscout_url }}

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -252,24 +252,33 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
-            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
 
             # Build constructor args if present
             CONSTRUCTOR_ARGS_FLAG=""
-            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+
+            # Check if arguments exist in the transaction
+            if echo "$tx" | jq -e '.arguments | length > 0' >/dev/null 2>&1; then
               # Get constructor signature from compiled contract ABI
-              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+              ABI_JSON=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null) || true
 
-              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
-                # Convert JSON array to space-separated args for cast
-                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
-                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+              if [[ -n "$ABI_JSON" ]] && echo "$ABI_JSON" | jq -e '.' >/dev/null 2>&1; then
+                CONSTRUCTOR_SIG=$(echo "$ABI_JSON" | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
 
-                if [[ -n "$ENCODED_ARGS" ]]; then
-                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
-                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                  # Build args array for cast - each arg needs to be passed separately
+                  ENCODED_ARGS=""
+                  mapfile -t ARGS_ARRAY < <(echo "$tx" | jq -r '.arguments[]')
+
+                  if [[ ${#ARGS_ARRAY[@]} -gt 0 ]]; then
+                    ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" "${ARGS_ARRAY[@]}" 2>/dev/null) || true
+                  fi
+
+                  if [[ -n "$ENCODED_ARGS" ]]; then
+                    CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                    echo "  Constructor args encoded: $ENCODED_ARGS"
+                  fi
                 fi
               fi
             fi
@@ -378,24 +387,33 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
-            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
 
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
 
             # Build constructor args if present
             CONSTRUCTOR_ARGS_FLAG=""
-            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+
+            # Check if arguments exist in the transaction
+            if echo "$tx" | jq -e '.arguments | length > 0' >/dev/null 2>&1; then
               # Get constructor signature from compiled contract ABI
-              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+              ABI_JSON=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null) || true
 
-              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
-                # Convert JSON array to space-separated args for cast
-                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
-                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+              if [[ -n "$ABI_JSON" ]] && echo "$ABI_JSON" | jq -e '.' >/dev/null 2>&1; then
+                CONSTRUCTOR_SIG=$(echo "$ABI_JSON" | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
 
-                if [[ -n "$ENCODED_ARGS" ]]; then
-                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
-                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                  # Build args array for cast - each arg needs to be passed separately
+                  ENCODED_ARGS=""
+                  mapfile -t ARGS_ARRAY < <(echo "$tx" | jq -r '.arguments[]')
+
+                  if [[ ${#ARGS_ARRAY[@]} -gt 0 ]]; then
+                    ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" "${ARGS_ARRAY[@]}" 2>/dev/null) || true
+                  fi
+
+                  if [[ -n "$ENCODED_ARGS" ]]; then
+                    CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                    echo "  Constructor args encoded: $ENCODED_ARGS"
+                  fi
                 fi
               fi
             fi

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -208,6 +208,7 @@ jobs:
         if: steps.network.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -223,6 +224,7 @@ jobs:
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
+                --rpc-url "$RPC_URL" \
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
@@ -325,6 +327,7 @@ jobs:
         if: steps.network.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -340,6 +343,7 @@ jobs:
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
+                --rpc-url "$RPC_URL" \
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -5,6 +5,12 @@ name: Foundry CI/CD
 on:
   workflow_call:
     inputs:
+      # Profile Options
+      deployment-foundry-profile:
+        description: 'Foundry profile to use for deployment (must be defined in foundry.toml)'
+        type: string
+        default: ''
+
       # CI Options
       check-formatting:
         description: 'Run forge fmt --check'
@@ -101,6 +107,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ci]
     if: inputs.run-upgrade-safety
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,6 +117,17 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Validate Foundry profile
+        if: inputs.deployment-foundry-profile != ''
+        run: |
+          if ! grep -q "\[profile\.${{ inputs.deployment-foundry-profile }}\]" foundry.toml 2>/dev/null; then
+            echo "::error::Foundry profile '${{ inputs.deployment-foundry-profile }}' not found in foundry.toml"
+            echo "Available profiles:"
+            grep -E "^\[profile\." foundry.toml || echo "  (none found)"
+            exit 1
+          fi
+          echo "✓ Using Foundry profile: ${{ inputs.deployment-foundry-profile }}"
 
       - name: Run upgrade safety validation
         run: |
@@ -138,6 +157,8 @@ jobs:
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
       inputs.deploy-on-pr &&
       github.event_name == 'pull_request'
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -236,6 +257,8 @@ jobs:
       inputs.deploy-on-main &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main'
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -333,6 +356,8 @@ jobs:
       always() &&
       needs.deploy-mainnet.result == 'success' &&
       inputs.flatten-contracts
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -210,10 +210,15 @@ jobs:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
-          jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE" | while read -r tx; do
+          VERIFICATION_FAILED=false
+
+          # Use process substitution to avoid subshell issues with variable tracking
+          while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+
+            VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
@@ -221,17 +226,26 @@ jobs:
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
+                VERIFIED=true
                 break
               else
                 if [[ $attempt -lt 3 ]]; then
                   echo "Attempt $attempt failed, retrying in $((attempt * 30))s..."
                   sleep $((attempt * 30))
-                else
-                  echo "⚠ Verification pending for $CONTRACT_NAME after 3 attempts"
                 fi
               fi
             done
-          done
+
+            if [[ "$VERIFIED" == "false" ]]; then
+              echo "✗ Failed to verify $CONTRACT_NAME after 3 attempts"
+              VERIFICATION_FAILED=true
+            fi
+          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+
+          if [[ "$VERIFICATION_FAILED" == "true" ]]; then
+            echo "::error::One or more contracts failed verification"
+            exit 1
+          fi
 
       - name: Create deployment summary
         env:
@@ -313,10 +327,15 @@ jobs:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
-          jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE" | while read -r tx; do
+          VERIFICATION_FAILED=false
+
+          # Use process substitution to avoid subshell issues with variable tracking
+          while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+
+            VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
@@ -324,17 +343,26 @@ jobs:
                 --guess-constructor-args \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
+                VERIFIED=true
                 break
               else
                 if [[ $attempt -lt 3 ]]; then
                   echo "Attempt $attempt failed, retrying in $((attempt * 30))s..."
                   sleep $((attempt * 30))
-                else
-                  echo "⚠ Verification pending for $CONTRACT_NAME after 3 attempts"
                 fi
               fi
             done
-          done
+
+            if [[ "$VERIFIED" == "false" ]]; then
+              echo "✗ Failed to verify $CONTRACT_NAME after 3 attempts"
+              VERIFICATION_FAILED=true
+            fi
+          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+
+          if [[ "$VERIFICATION_FAILED" == "true" ]]; then
+            echo "::error::One or more contracts failed verification"
+            exit 1
+          fi
 
       - name: Create deployment summary
         env:

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -105,13 +105,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Build paths filter
+        id: paths
+        run: |
+          # Convert newline-separated paths to YAML list format
+          YAML_PATHS=$(echo "${{ inputs.contract-paths }}" | sed '/^$/d' | sed 's/^/    - /')
+          echo "filter<<EOF" >> $GITHUB_OUTPUT
+          echo "contracts:" >> $GITHUB_OUTPUT
+          echo "$YAML_PATHS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Check for contract changes
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          filters: |
-            contracts:
-              ${{ inputs.contract-paths }}
+          filters: ${{ steps.paths.outputs.filter }}
 
       - name: Decide whether to run
         id: decide

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -244,7 +244,6 @@ jobs:
         if: needs.read-testnet-config.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ needs.read-testnet-config.outputs.blockscout_url }}
-          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -253,15 +252,34 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
+            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
+
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+
+            # Build constructor args if present
+            CONSTRUCTOR_ARGS_FLAG=""
+            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+              # Get constructor signature from compiled contract ABI
+              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+
+              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                # Convert JSON array to space-separated args for cast
+                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
+                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+
+                if [[ -n "$ENCODED_ARGS" ]]; then
+                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                fi
+              fi
+            fi
 
             VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
-                --rpc-url "$RPC_URL" \
-                --guess-constructor-args \
+                $CONSTRUCTOR_ARGS_FLAG \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
                 VERIFIED=true
@@ -352,7 +370,6 @@ jobs:
         if: needs.read-mainnet-config.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ needs.read-mainnet-config.outputs.blockscout_url }}
-          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
           VERIFICATION_FAILED=false
@@ -361,15 +378,34 @@ jobs:
           while read -r tx; do
             CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
             CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
+            ARGS=$(echo "$tx" | jq -c '.arguments // empty')
+
             echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+
+            # Build constructor args if present
+            CONSTRUCTOR_ARGS_FLAG=""
+            if [[ -n "$ARGS" && "$ARGS" != "null" && "$ARGS" != "[]" ]]; then
+              # Get constructor signature from compiled contract ABI
+              CONSTRUCTOR_SIG=$(forge inspect "$CONTRACT_NAME" abi 2>/dev/null | jq -r '.[] | select(.type == "constructor") | .inputs | map(.type) | join(",")')
+
+              if [[ -n "$CONSTRUCTOR_SIG" ]]; then
+                # Convert JSON array to space-separated args for cast
+                ARGS_LIST=$(echo "$ARGS" | jq -r '.[]' | tr '\n' ' ')
+                ENCODED_ARGS=$(cast abi-encode "constructor($CONSTRUCTOR_SIG)" $ARGS_LIST 2>/dev/null) || true
+
+                if [[ -n "$ENCODED_ARGS" ]]; then
+                  CONSTRUCTOR_ARGS_FLAG="--constructor-args $ENCODED_ARGS"
+                  echo "  Constructor args encoded: $ENCODED_ARGS"
+                fi
+              fi
+            fi
 
             VERIFIED=false
             for attempt in 1 2 3; do
               if forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
                 --verifier blockscout \
                 --verifier-url "${BLOCKSCOUT_URL}/api" \
-                --rpc-url "$RPC_URL" \
-                --guess-constructor-args \
+                $CONSTRUCTOR_ARGS_FLAG \
                 --watch; then
                 echo "✓ Verified $CONTRACT_NAME"
                 VERIFIED=true

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -147,16 +147,60 @@ jobs:
             echo "No baseline contracts found, skipping upgrade validation (initial deployment)"
           fi
 
+  read-testnet-config:
+    name: Read Testnet Config
+    runs-on: ubuntu-latest
+    if: inputs.deploy-on-pr && github.event_name == 'pull_request'
+    outputs:
+      blockscout_url: ${{ steps.network.outputs.blockscout_url }}
+      network_name: ${{ steps.network.outputs.network_name }}
+      environment: ${{ steps.network.outputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read network config
+        id: network
+        run: |
+          BLOCKSCOUT_URL=$(jq -r '.testnets[0].blockscout_url' ${{ inputs.network-config-path }})
+          NETWORK_NAME=$(jq -r '.testnets[0].name' ${{ inputs.network-config-path }})
+          ENVIRONMENT=$(jq -r '.testnets[0].environment' ${{ inputs.network-config-path }})
+          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
+          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+
+  read-mainnet-config:
+    name: Read Mainnet Config
+    runs-on: ubuntu-latest
+    if: inputs.deploy-on-main && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      blockscout_url: ${{ steps.network.outputs.blockscout_url }}
+      network_name: ${{ steps.network.outputs.network_name }}
+      environment: ${{ steps.network.outputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Read network config
+        id: network
+        run: |
+          BLOCKSCOUT_URL=$(jq -r '.mainnets[0].blockscout_url' ${{ inputs.network-config-path }})
+          NETWORK_NAME=$(jq -r '.mainnets[0].name' ${{ inputs.network-config-path }})
+          ENVIRONMENT=$(jq -r '.mainnets[0].environment' ${{ inputs.network-config-path }})
+          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
+          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+
   deploy-testnet:
     name: Deploy Testnet
     runs-on: ubuntu-latest
-    needs: [ci, upgrade-safety]
+    needs: [ci, upgrade-safety, read-testnet-config]
+    environment: ${{ needs.read-testnet-config.outputs.environment }}
     if: |
       always() &&
       needs.ci.result == 'success' &&
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
-      inputs.deploy-on-pr &&
-      github.event_name == 'pull_request'
+      needs.read-testnet-config.result == 'success'
     env:
       FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
@@ -167,14 +211,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Read network config
-        id: network
-        run: |
-          BLOCKSCOUT_URL=$(jq -r '.testnets[0].blockscout_url' ${{ inputs.network-config-path }})
-          NETWORK_NAME=$(jq -r '.testnets[0].name' ${{ inputs.network-config-path }})
-          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
-          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
 
       - name: Deploy contracts
         env:
@@ -205,9 +241,9 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
-        if: steps.network.outputs.blockscout_url != ''
+        if: needs.read-testnet-config.outputs.blockscout_url != ''
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.read-testnet-config.outputs.blockscout_url }}
           RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
@@ -251,7 +287,7 @@ jobs:
 
       - name: Create deployment summary
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.read-testnet-config.outputs.blockscout_url }}
         run: |
           echo "## Testnet Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -266,14 +302,13 @@ jobs:
   deploy-mainnet:
     name: Deploy Mainnet
     runs-on: ubuntu-latest
-    needs: [ci, upgrade-safety]
+    needs: [ci, upgrade-safety, read-mainnet-config]
+    environment: ${{ needs.read-mainnet-config.outputs.environment }}
     if: |
       always() &&
       needs.ci.result == 'success' &&
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
-      inputs.deploy-on-main &&
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
+      needs.read-mainnet-config.result == 'success'
     env:
       FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
@@ -284,16 +319,6 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Read network config
-        id: network
-        run: |
-          BLOCKSCOUT_URL=$(jq -r '.mainnets[0].blockscout_url' ${{ inputs.network-config-path }})
-          NETWORK_NAME=$(jq -r '.mainnets[0].name' ${{ inputs.network-config-path }})
-          ENVIRONMENT=$(jq -r '.mainnets[0].environment' ${{ inputs.network-config-path }})
-          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
-          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
-          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
 
       - name: Deploy contracts
         env:
@@ -324,9 +349,9 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
-        if: steps.network.outputs.blockscout_url != ''
+        if: needs.read-mainnet-config.outputs.blockscout_url != ''
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.read-mainnet-config.outputs.blockscout_url }}
           RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
@@ -370,7 +395,7 @@ jobs:
 
       - name: Create deployment summary
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.read-mainnet-config.outputs.blockscout_url }}
         run: |
           echo "## Mainnet Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -205,6 +205,7 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
+        if: steps.network.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
         run: |
@@ -307,6 +308,7 @@ jobs:
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
 
       - name: Verify contracts on Blockscout
+        if: steps.network.outputs.blockscout_url != ''
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
         run: |

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -5,6 +5,10 @@ name: Upgrade Safety (Reusable)
 on:
   workflow_call:
     inputs:
+      deployment-foundry-profile:
+        description: 'Foundry profile to use for deployment (must be defined in foundry.toml)'
+        type: string
+        default: ''
       baseline-path:
         description: 'Path to baseline contracts for comparison'
         type: string
@@ -22,6 +26,8 @@ jobs:
   upgrade-safety:
     name: Validate Upgrade Safety
     runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: ${{ inputs.deployment-foundry-profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -83,12 +83,41 @@ Create `.github/deploy-networks.json` in your repository:
 | `PRIVATE_KEY` | Deployer wallet private key |
 | `RPC_URL` | Network RPC endpoint |
 
+## Deployment Profiles
+
+Use `deployment-foundry-profile` to specify a Foundry profile for deployments while keeping CI tests on the default profile. This is useful when tests fail with high optimizer settings but production needs maximum optimization.
+
+```yaml
+jobs:
+  deploy:
+    uses: BreadchainCoop/etherform/.github/workflows/_deploy-mainnet.yml@main
+    with:
+      deployment-foundry-profile: 'production'
+    secrets:
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+      RPC_URL: ${{ secrets.RPC_URL }}
+```
+
+Define profiles in your `foundry.toml`:
+
+```toml
+[profile.default]
+optimizer = false
+
+[profile.production]
+optimizer = true
+optimizer_runs = 1000000
+```
+
+The profile applies to deployment, upgrade safety, verification, and flattening steps. CI tests run with the default profile.
+
 ## Workflow Inputs
 
 ### `_ci.yml`
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
+| `deployment-foundry-profile` | string | `''` | Foundry profile (optional, for standalone use) |
 | `check-formatting` | boolean | `true` | Run `forge fmt --check` |
 | `test-verbosity` | string | `'vvv'` | Test verbosity (`v`, `vv`, `vvv`, `vvvv`) |
 
@@ -96,6 +125,7 @@ Create `.github/deploy-networks.json` in your repository:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
+| `deployment-foundry-profile` | string | `''` | Foundry profile for deployment |
 | `baseline-path` | string | `'test/upgrades/baseline'` | Path to baseline contracts |
 | `fallback-path` | string | `'test/upgrades/previous'` | Fallback path if baseline missing |
 | `validation-script` | string | `'script/upgrades/ValidateUpgrade.s.sol'` | Validation script path |
@@ -104,6 +134,7 @@ Create `.github/deploy-networks.json` in your repository:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
+| `deployment-foundry-profile` | string | `''` | Foundry profile for deployment |
 | `deploy-script` | string | `'script/Deploy.s.sol:Deploy'` | Deployment script |
 | `network-config-path` | string | `'.github/deploy-networks.json'` | Network config path |
 | `network-index` | number | `0` | Index in testnets array |
@@ -113,6 +144,7 @@ Create `.github/deploy-networks.json` in your repository:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
+| `deployment-foundry-profile` | string | `''` | Foundry profile for deployment |
 | `deploy-script` | string | `'script/Deploy.s.sol:Deploy'` | Deployment script |
 | `network-config-path` | string | `'.github/deploy-networks.json'` | Network config path |
 | `network` | string | `''` | Specific network (empty = all) |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Create `.github/deploy-networks.json` in your repository:
 }
 ```
 
+**Note:** Contract verification on Blockscout is optional. If `blockscout_url` is omitted or empty for a network, verification is skipped.
+
 ### Secrets Required
 
 | Secret | Description |


### PR DESCRIPTION
## Summary

Major improvements to Etherform CI/CD workflows including deployment profiles, GitHub Environments support, and robust contract verification.

## Features

### Deployment Profiles (`deployment-foundry-profile`)
- Specify a Foundry profile for deployments while keeping CI tests on default profile
- Useful when tests fail with high optimizer settings but production needs optimization
- Profile applies to deployment, upgrade safety, verification, and flattening steps
- Profile validation catches undefined profiles early with helpful error messages

### GitHub Environments Support
- Deploy jobs now use `environment:` from network config for per-network secrets
- Restructured workflows with two-job pattern (read-config → deploy) to support environment resolution
- Secrets (PRIVATE_KEY, RPC_URL) resolve from GitHub Environments based on `"environment"` field in `deploy-networks.json`

### Robust Contract Verification
- **Optional verification**: Skip if `blockscout_url` is omitted/empty in network config
- **Proper failure handling**: Verification step fails when all retries are exhausted
- **Constructor args from broadcast**: Extract actual constructor args from broadcast artifacts instead of guessing
- **Library-linked contracts**: Works with contracts that use external libraries (fixes `--guess-constructor-args` failures)

## Commits

| Commit | Description |
|--------|-------------|
| `3ad9cf8` | Add all-in-one `_foundry-cicd.yml` reusable workflow |
| `3c3048e` | Add `deployment-foundry-profile` input to all workflows |
| `58ddecd` | Document deployment profiles in README |
| `77f745e` | Make Blockscout verification optional |
| `9d2381f` | Fix verification to actually fail when retries exhausted |
| `7b38f11` | Pass RPC_URL to verification (required for `--guess-constructor-args`) |
| `b9a5466` | Add GitHub Environments support for per-network secrets |
| `f5b700a` | Use broadcast artifacts for constructor args in verification |
| `e82dcdb` | Fix jq parse errors with robust arg handling |

## Usage

```yaml
jobs:
  deploy:
    uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@main
    with:
      deployment-foundry-profile: 'production'
      deploy-on-pr: true
    secrets:
      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
      RPC_URL: ${{ secrets.RPC_URL }}
```

Network config with environments:
```json
{
  "testnets": [{
    "name": "sepolia",
    "blockscout_url": "https://eth-sepolia.blockscout.com",
    "environment": "testnet-sepolia"
  }],
  "mainnets": [{
    "name": "ethereum",
    "blockscout_url": "https://eth.blockscout.com",
    "environment": "production-ethereum"
  }]
}
```


closes #8, closes  #7, closes #4

Tested with integration wit this repo https://github.com/PerpetualOrganizationArchitect/POP/actions/runs/19974105263/job/57286120003?pr=54
🤖 Generated with [Claude Code](https://claude.com/claude-code)