### PR TITLE
feat: add smart contract change detection to CI/CD

### DIFF
--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -5,6 +5,22 @@ name: Foundry CI/CD
 on:
   workflow_call:
     inputs:
+      # Change Detection Options
+      skip-if-no-changes:
+        description: 'Skip workflow if no smart contract files changed'
+        type: boolean
+        default: true
+      contract-paths:
+        description: 'Paths to check for changes (newline-separated glob patterns)'
+        type: string
+        default: |
+          src/**
+          script/**
+          test/**
+          lib/**
+          foundry.toml
+          remappings.txt
+
       # CI Options
       check-formatting:
         description: 'Run forge fmt --check'
@@ -71,9 +87,45 @@ on:
         required: false
 
 jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      contracts-changed: ${{ steps.filter.outputs.contracts }}
+      should-run: ${{ steps.decide.outputs.should-run }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for contract changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            contracts:
+              ${{ inputs.contract-paths }}
+
+      - name: Decide whether to run
+        id: decide
+        run: |
+          if [[ "${{ inputs.skip-if-no-changes }}" == "false" ]]; then
+            echo "Change detection disabled, workflow will run"
+            echo "should-run=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.filter.outputs.contracts }}" == "true" ]]; then
+            echo "Contract changes detected, workflow will run"
+            echo "should-run=true" >> $GITHUB_OUTPUT
+          else
+            echo "No contract changes detected, skipping workflow"
+            echo "should-run=false" >> $GITHUB_OUTPUT
+          fi
+
   ci:
     name: Build & Test
     runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -99,8 +151,10 @@ jobs:
   upgrade-safety:
     name: Upgrade Safety
     runs-on: ubuntu-latest
-    needs: [ci]
-    if: inputs.run-upgrade-safety
+    needs: [detect-changes, ci]
+    if: |
+      needs.detect-changes.outputs.should-run == 'true' &&
+      inputs.run-upgrade-safety
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -131,9 +185,10 @@ jobs:
   deploy-testnet:
     name: Deploy Testnet
     runs-on: ubuntu-latest
-    needs: [ci, upgrade-safety]
+    needs: [detect-changes, ci, upgrade-safety]
     if: |
       always() &&
+      needs.detect-changes.outputs.should-run == 'true' &&
       needs.ci.result == 'success' &&
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
       inputs.deploy-on-pr &&
@@ -228,9 +283,10 @@ jobs:
   deploy-mainnet:
     name: Deploy Mainnet
     runs-on: ubuntu-latest
-    needs: [ci, upgrade-safety]
+    needs: [detect-changes, ci, upgrade-safety]
     if: |
       always() &&
+      needs.detect-changes.outputs.should-run == 'true' &&
       needs.ci.result == 'success' &&
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
       inputs.deploy-on-main &&


### PR DESCRIPTION
## Summary
- Adds change detection job to skip expensive CI/CD operations when only non-contract files are modified
- Uses `dorny/paths-filter@v3` to detect changes in smart contract directories and configuration
- All CI/CD jobs (CI, upgrade safety, deployments) now conditionally run based on detected changes

## Configuration
- New input `skip-if-no-changes` (default: true) allows disabling change detection if needed
- Monitors: `src/**`, `script/**`, `test/**`, `lib/**`, `foundry.toml`, `remappings.txt`
- Can be customized via `contract-paths` input


closes #10 
🤖 Generated with [Claude Code](https://claude.com/claude-code)