### PR TITLE
fix: resolve paths-filter YAML syntax error

### DIFF
--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -99,13 +99,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Build paths filter
+        id: paths
+        run: |
+          # Convert newline-separated paths to YAML list format
+          YAML_PATHS=$(echo "${{ inputs.contract-paths }}" | sed '/^$/d' | sed 's/^/    - /')
+          echo "filter<<EOF" >> $GITHUB_OUTPUT
+          echo "contracts:" >> $GITHUB_OUTPUT
+          echo "$YAML_PATHS" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Check for contract changes
         id: filter
         uses: dorny/paths-filter@v3
         with:
-          filters: |
-            contracts:
-              ${{ inputs.contract-paths }}
+          filters: ${{ steps.paths.outputs.filter }}
 
       - name: Decide whether to run
         id: decide


### PR DESCRIPTION
## Summary
Convert multiline contract-paths input to properly formatted YAML list for dorny/paths-filter. This fixes the error: "can not read a block mapping entry; a multiline key may not be an implicit key"

## Changes
- Add preprocessing step to convert newline-separated paths to YAML list format
- Fixes compatibility with dorny/paths-filter@v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)