### PR TITLE
Add Slither static analysis to CI/CD workflows

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -13,6 +13,18 @@ on:
         description: 'Test verbosity level (v, vv, vvv, vvvv)'
         type: string
         default: 'vvv'
+      run-slither:
+        description: 'Run Slither static analysis'
+        type: boolean
+        default: false
+      slither-fail-on:
+        description: 'Minimum severity to fail on (low, medium, high)'
+        type: string
+        default: 'high'
+      slither-config:
+        description: 'Path to slither.config.json'
+        type: string
+        default: 'slither.config.json'
 
 jobs:
   check:
@@ -39,3 +51,25 @@ jobs:
 
       - name: Run tests
         run: forge test -${{ inputs.test-verbosity }}
+
+  slither:
+    name: Slither Analysis
+    runs-on: ubuntu-latest
+    if: inputs.run-slither
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Build for Slither
+        run: forge build --build-info --skip '*/test/**' '*/script/**' --force
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.4.0
+        with:
+          slither-config: ${{ inputs.slither-config }}
+          fail-on: ${{ inputs.slither-fail-on }}

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -31,6 +31,20 @@ on:
         type: string
         default: 'vvv'
 
+      # Slither Options
+      run-slither:
+        description: 'Run Slither static analysis'
+        type: boolean
+        default: false
+      slither-fail-on:
+        description: 'Minimum severity to fail on (low, medium, high)'
+        type: string
+        default: 'high'
+      slither-config:
+        description: 'Path to slither.config.json'
+        type: string
+        default: 'slither.config.json'
+
       # Upgrade Safety Options
       run-upgrade-safety:
         description: 'Run upgrade safety validation'
@@ -155,6 +169,31 @@ jobs:
 
       - name: Run tests
         run: forge test -${{ inputs.test-verbosity }}
+
+  slither:
+    name: Slither Analysis
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      needs.detect-changes.outputs.should-run == 'true' &&
+      inputs.run-slither
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Build for Slither
+        run: forge build --build-info --skip '*/test/**' '*/script/**' --force
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.4.0
+        with:
+          slither-config: ${{ inputs.slither-config }}
+          fail-on: ${{ inputs.slither-fail-on }}
 
   upgrade-safety:
     name: Upgrade Safety


### PR DESCRIPTION
## Summary
Added optional Slither static analysis support to both `_ci.yml` and `_foundry-cicd.yml` reusable workflows. Follows the pattern from token-factory-playground with configurable severity levels and config paths.

## Features
- Three new inputs: `run-slither`, `slither-fail-on`, `slither-config`
- Slither job runs in parallel with CI (respects change detection in all-in-one workflow)
- Disabled by default to avoid breaking existing consumers
- Uses `crytic/slither-action@v0.4.0` with Forge build optimization

## Test plan
- Existing workflows unaffected (run-slither defaults to false)
- Consumers can opt-in by passing run-slither: true and providing slither.config.json

🤖 Generated with Claude Code