### PR TITLE
Fix Blockscout verification false positives and add blocking behavior

### DIFF
--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -131,6 +131,7 @@ jobs:
       - name: Create deployment summary
         env:
           BLOCKSCOUT_URL: ${{ matrix.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           echo "## ${{ matrix.name }} Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -147,6 +148,7 @@ jobs:
         if: inputs.verify-contracts
         env:
           BLOCKSCOUT_URL: ${{ matrix.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           # Validate Blockscout URL format (fail fast on bad URL)
           if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -105,6 +105,7 @@ jobs:
       - name: Create deployment summary
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           echo "## Testnet Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -121,6 +122,7 @@ jobs:
         if: inputs.verify-contracts
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           # Validate Blockscout URL format (fail fast on bad URL)
           if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -292,6 +292,7 @@ jobs:
       - name: Create deployment summary
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           echo "## Testnet Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -307,6 +308,7 @@ jobs:
         if: inputs.verify-contracts
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           # Validate Blockscout URL format (fail fast on bad URL)
           if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then
@@ -421,6 +423,7 @@ jobs:
       - name: Create deployment summary
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           echo "## Mainnet Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -436,6 +439,7 @@ jobs:
         if: inputs.verify-contracts
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           # Validate Blockscout URL format (fail fast on bad URL)
           if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then


### PR DESCRIPTION
## Problem
Three critical issues in Blockscout verification:
- **#16**: False positives — CI reports success when Blockscout verification fails
- **#8**: Bad URL infinite loop — missing validation and timeout
- **#7**: Verification is mandatory — no way to skip it

## Solution
- Capture `forge verify-contract` output and check for actual success strings ("Contract successfully verified", "Pass - Verified") instead of trusting exit code (which returns 0 even on "Fail - Unable to verify")
- Validate Blockscout URL format upfront; wrap forge with 120s timeout
- Add `verify-contracts` boolean input (default: true) to make it optional
- Use process substitution (`done < <(jq)`) instead of pipe so failure tracking propagates; step now exits 1 when any contract fails

## Testing
Tested with mock forge binary under GitHub Actions shell mode (bash -eo pipefail):
- ✓ False positive correctly detected and step fails
- ✓ Real success passes
- ✓ Already verified passes
- ✓ Network errors fail
- ✓ Bad URLs fail immediately
- ✓ Timeout prevents hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)