### PR TITLE
feat: add coverage report job to CI workflows

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -25,6 +25,22 @@ on:
         description: 'Path to slither.config.json'
         type: string
         default: 'slither.config.json'
+      run-coverage:
+        description: 'Run forge coverage and post PR comment'
+        type: boolean
+        default: false
+      coverage-exclude-paths:
+        description: 'Path pattern to exclude from coverage (--no-match-path)'
+        type: string
+        default: ''
+      coverage-source-filter:
+        description: 'Grep filter for source files in coverage report'
+        type: string
+        default: ' src/'
+      coverage-post-comment:
+        description: 'Post coverage summary as a sticky PR comment'
+        type: boolean
+        default: true
 
 jobs:
   check:
@@ -73,3 +89,89 @@ jobs:
         with:
           slither-config: ${{ inputs.slither-config }}
           fail-on: ${{ inputs.slither-fail-on }}
+
+  coverage:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    needs: [check]
+    if: inputs.run-coverage
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Forge version
+        run: forge --version
+
+      - name: Run coverage
+        run: |
+          if [[ -n "${{ inputs.coverage-exclude-paths }}" ]]; then
+            forge coverage --no-match-path "${{ inputs.coverage-exclude-paths }}" 2>&1 | tee coverage-raw.txt
+          else
+            forge coverage 2>&1 | tee coverage-raw.txt
+          fi
+
+      - name: Extract summary table
+        run: |
+          # Extract the final summary table (box-drawing characters)
+          awk '/^╭/,/^╰/' coverage-raw.txt > coverage-table.txt
+
+          # Filter to only source files and compute totals from raw counts
+          grep '^|' coverage-table.txt | grep '${{ inputs.coverage-source-filter }}' > src-rows.txt || true
+
+          # Sum up hit/total for each metric across source files
+          total_lines_hit=0; total_lines_all=0
+          total_stmts_hit=0; total_stmts_all=0
+          total_branch_hit=0; total_branch_all=0
+          total_funcs_hit=0; total_funcs_all=0
+
+          while IFS='|' read -r _ file lines stmts branches funcs _; do
+            extract() { echo "$1" | grep -oP '\(\K[0-9]+/[0-9]+' | tr '/' ' '; }
+            read lh lt <<< "$(extract "$lines")"
+            read sh st <<< "$(extract "$stmts")"
+            read bh bt <<< "$(extract "$branches")"
+            read fh ft <<< "$(extract "$funcs")"
+            total_lines_hit=$((total_lines_hit + lh)); total_lines_all=$((total_lines_all + lt))
+            total_stmts_hit=$((total_stmts_hit + sh)); total_stmts_all=$((total_stmts_all + st))
+            total_branch_hit=$((total_branch_hit + bh)); total_branch_all=$((total_branch_all + bt))
+            total_funcs_hit=$((total_funcs_hit + fh)); total_funcs_all=$((total_funcs_all + ft))
+          done < src-rows.txt
+
+          pct() { [ "$2" -eq 0 ] && echo "100.00% (0/0)" || printf "%.2f%% (%d/%d)" "$(echo "scale=4; $1 * 100 / $2" | bc)" "$1" "$2"; }
+
+          # Build the markdown comment
+          {
+            echo "## Coverage Report"
+            echo ""
+            echo "| Metric | Coverage |"
+            echo "|--------|----------|"
+            echo "| Lines | $(pct $total_lines_hit $total_lines_all) |"
+            echo "| Statements | $(pct $total_stmts_hit $total_stmts_all) |"
+            echo "| Branches | $(pct $total_branch_hit $total_branch_all) |"
+            echo "| Functions | $(pct $total_funcs_hit $total_funcs_all) |"
+            echo ""
+            echo "<details><summary>Coverage by file</summary>"
+            echo ""
+            echo "| File | Lines | Statements | Branches | Functions |"
+            echo "|------|-------|------------|----------|-----------|"
+            while IFS='|' read -r _ file lines stmts branches funcs _; do
+              file=$(echo "$file" | xargs)
+              lines=$(echo "$lines" | xargs)
+              stmts=$(echo "$stmts" | xargs)
+              branches=$(echo "$branches" | xargs)
+              funcs=$(echo "$funcs" | xargs)
+              echo "| \`$file\` | $lines | $stmts | $branches | $funcs |"
+            done < src-rows.txt
+            echo ""
+            echo "</details>"
+          } > coverage-comment.md
+
+      - name: Post coverage comment
+        if: inputs.coverage-post-comment && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: coverage-comment.md

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -45,6 +45,24 @@ on:
         type: string
         default: 'slither.config.json'
 
+      # Coverage Options
+      run-coverage:
+        description: 'Run forge coverage and post PR comment'
+        type: boolean
+        default: false
+      coverage-exclude-paths:
+        description: 'Path pattern to exclude from coverage (--no-match-path)'
+        type: string
+        default: ''
+      coverage-source-filter:
+        description: 'Grep filter for source files in coverage report'
+        type: string
+        default: ' src/'
+      coverage-post-comment:
+        description: 'Post coverage summary as a sticky PR comment'
+        type: boolean
+        default: true
+
       # Upgrade Safety Options
       run-upgrade-safety:
         description: 'Run upgrade safety validation'
@@ -198,6 +216,96 @@ jobs:
         with:
           slither-config: ${{ inputs.slither-config }}
           fail-on: ${{ inputs.slither-fail-on }}
+
+  coverage:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    needs: [detect-changes, ci]
+    if: |
+      always() &&
+      needs.detect-changes.outputs.should-run == 'true' &&
+      needs.ci.result == 'success' &&
+      inputs.run-coverage
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Forge version
+        run: forge --version
+
+      - name: Run coverage
+        run: |
+          if [[ -n "${{ inputs.coverage-exclude-paths }}" ]]; then
+            forge coverage --no-match-path "${{ inputs.coverage-exclude-paths }}" 2>&1 | tee coverage-raw.txt
+          else
+            forge coverage 2>&1 | tee coverage-raw.txt
+          fi
+
+      - name: Extract summary table
+        run: |
+          # Extract the final summary table (box-drawing characters)
+          awk '/^╭/,/^╰/' coverage-raw.txt > coverage-table.txt
+
+          # Filter to only source files and compute totals from raw counts
+          grep '^|' coverage-table.txt | grep '${{ inputs.coverage-source-filter }}' > src-rows.txt || true
+
+          # Sum up hit/total for each metric across source files
+          total_lines_hit=0; total_lines_all=0
+          total_stmts_hit=0; total_stmts_all=0
+          total_branch_hit=0; total_branch_all=0
+          total_funcs_hit=0; total_funcs_all=0
+
+          while IFS='|' read -r _ file lines stmts branches funcs _; do
+            extract() { echo "$1" | grep -oP '\(\K[0-9]+/[0-9]+' | tr '/' ' '; }
+            read lh lt <<< "$(extract "$lines")"
+            read sh st <<< "$(extract "$stmts")"
+            read bh bt <<< "$(extract "$branches")"
+            read fh ft <<< "$(extract "$funcs")"
+            total_lines_hit=$((total_lines_hit + lh)); total_lines_all=$((total_lines_all + lt))
+            total_stmts_hit=$((total_stmts_hit + sh)); total_stmts_all=$((total_stmts_all + st))
+            total_branch_hit=$((total_branch_hit + bh)); total_branch_all=$((total_branch_all + bt))
+            total_funcs_hit=$((total_funcs_hit + fh)); total_funcs_all=$((total_funcs_all + ft))
+          done < src-rows.txt
+
+          pct() { [ "$2" -eq 0 ] && echo "100.00% (0/0)" || printf "%.2f%% (%d/%d)" "$(echo "scale=4; $1 * 100 / $2" | bc)" "$1" "$2"; }
+
+          # Build the markdown comment
+          {
+            echo "## Coverage Report"
+            echo ""
+            echo "| Metric | Coverage |"
+            echo "|--------|----------|"
+            echo "| Lines | $(pct $total_lines_hit $total_lines_all) |"
+            echo "| Statements | $(pct $total_stmts_hit $total_stmts_all) |"
+            echo "| Branches | $(pct $total_branch_hit $total_branch_all) |"
+            echo "| Functions | $(pct $total_funcs_hit $total_funcs_all) |"
+            echo ""
+            echo "<details><summary>Coverage by file</summary>"
+            echo ""
+            echo "| File | Lines | Statements | Branches | Functions |"
+            echo "|------|-------|------------|----------|-----------|"
+            while IFS='|' read -r _ file lines stmts branches funcs _; do
+              file=$(echo "$file" | xargs)
+              lines=$(echo "$lines" | xargs)
+              stmts=$(echo "$stmts" | xargs)
+              branches=$(echo "$branches" | xargs)
+              funcs=$(echo "$funcs" | xargs)
+              echo "| \`$file\` | $lines | $stmts | $branches | $funcs |"
+            done < src-rows.txt
+            echo ""
+            echo "</details>"
+          } > coverage-comment.md
+
+      - name: Post coverage comment
+        if: inputs.coverage-post-comment && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: coverage-comment.md
 
   upgrade-safety:
     name: Upgrade Safety

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Reusable GitHub Actions workflows for Foundry smart contract CI/CD with upgrade 
 
 | Workflow | Description |
 |----------|-------------|
-| `_ci.yml` | Build, test, and format check |
+| `_ci.yml` | Build, test, format check, and coverage report |
 | `_upgrade-safety.yml` | OpenZeppelin upgrade safety validation |
 | `_deploy-testnet.yml` | Testnet deployment with Blockscout verification |
 | `_deploy-mainnet.yml` | Mainnet deployment with matrix support and 3-tier snapshot rotation |
@@ -47,6 +47,25 @@ jobs:
     secrets:
       PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
       RPC_URL: ${{ secrets.RPC_URL }}
+```
+
+```yaml
+# .github/workflows/ci.yml (with coverage)
+name: CI
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ci:
+    uses: BreadchainCoop/etherform/.github/workflows/_ci.yml@main
+    with:
+      check-formatting: true
+      run-coverage: true
+      coverage-exclude-paths: 'test/fork/**'
 ```
 
 ## Configuration
@@ -91,6 +110,15 @@ Create `.github/deploy-networks.json` in your repository:
 |-------|------|---------|-------------|
 | `check-formatting` | boolean | `true` | Run `forge fmt --check` |
 | `test-verbosity` | string | `'vvv'` | Test verbosity (`v`, `vv`, `vvv`, `vvvv`) |
+| `run-slither` | boolean | `false` | Run Slither static analysis |
+| `slither-fail-on` | string | `'high'` | Minimum severity to fail on (`low`, `medium`, `high`) |
+| `slither-config` | string | `'slither.config.json'` | Path to slither.config.json |
+| `run-coverage` | boolean | `false` | Run `forge coverage` and post PR comment |
+| `coverage-exclude-paths` | string | `''` | Path pattern to exclude from coverage (`--no-match-path`) |
+| `coverage-source-filter` | string | `' src/'` | Grep filter for source files in coverage report |
+| `coverage-post-comment` | boolean | `true` | Post coverage summary as a sticky PR comment |
+
+> **Note:** When `run-coverage` and `coverage-post-comment` are enabled, the calling workflow must have `pull-requests: write` permission for the sticky comment to be posted.
 
 ### `_upgrade-safety.yml`
 

--- a/docs/specs/ci-cd-automated-deployments.md
+++ b/docs/specs/ci-cd-automated-deployments.md
@@ -692,6 +692,14 @@ flowchart TD
         J -->|Pass| K[Success]
         J -->|Fail| X
     end
+
+    subgraph "Job: coverage (opt-in)"
+        B --> COV1[Checkout Repository]
+        COV1 --> COV2[Install Foundry]
+        COV2 --> COV3[forge coverage]
+        COV3 --> COV4[Extract summary table]
+        COV4 --> COV5[Post sticky PR comment]
+    end
 ```
 
 ---
@@ -707,4 +715,5 @@ flowchart TD
 | **Verifier** | Blockscout | Blockscout | Etherscan | N/A |
 | **Wait Time** | 60s | 60s | 300s | N/A |
 | **Format Check** | No | No | No | Yes |
+| **Coverage Report** | No | No | No | Opt-in |
 | **Contract Deploy** | Yes | Yes | Yes | No |


### PR DESCRIPTION
## Summary

Added an optional coverage reporting job to both `_ci.yml` and `_foundry-cicd.yml` that runs `forge coverage`, parses per-file metrics, and posts a sticky PR comment with a summary table and expandable details section. The feature is disabled by default and includes configurable inputs for excluding paths and filtering source files.

## Details

- **Coverage job in `_ci.yml`**: New optional job that runs after successful tests (`needs: [check]`). Disabled by default with `run-coverage: false`.
- **Coverage job in `_foundry-cicd.yml`**: Inline job that runs after CI passes with proper gating on `should-run` and `ci.result == 'success'`.
- **PR comment gating**: Comment is only posted on `pull_request` events and when both `run-coverage` and `coverage-post-comment` are enabled.
- **Secure command handling**: Uses conditional bash instead of `eval` to avoid injection vulnerabilities.
- **Robust parsing**: Includes `|| true` on grep to handle edge cases where no matching files exist.
- **Documentation**: Updated README with 4 new coverage inputs and usage example, added coverage to workflow comparison table in spec.

## Inputs

- `run-coverage` (boolean, default `false`) - Enable coverage job
- `coverage-exclude-paths` (string, default `''`) - Paths to exclude from forge coverage
- `coverage-source-filter` (string, default `' src/'`) - Grep pattern for files to include in report
- `coverage-post-comment` (boolean, default `true`) - Post sticky comment on PRs

## Test Plan

- [x] YAML syntax validation with yaml-lint
- [x] Input consistency between `_ci.yml` and `_foundry-cicd.yml`
- [x] Coverage job depends on tests passing (won't report on test failure)
- [x] PR comment gracefully skips on non-PR events
- [x] README documents all new inputs and permissions requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)