### PR TITLE
fix: resolve blockscout URL from deployed chain ID

### DIFF
--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -361,14 +361,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Read network config
-        id: network
-        run: |
-          BLOCKSCOUT_URL=$(jq -r '.testnets[0].blockscout_url' ${{ inputs.network-config-path }})
-          NETWORK_NAME=$(jq -r '.testnets[0].name' ${{ inputs.network-config-path }})
-          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
-          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
-
       - name: Deploy contracts
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
@@ -395,7 +387,43 @@ jobs:
             exit 1
           fi
           echo "broadcast_file=$BROADCAST_FILE" >> $GITHUB_OUTPUT
+
+          # Extract the chain ID from the broadcast file path (broadcast/<script>/<chain_id>/run-latest.json)
+          CHAIN_ID=$(echo "$BROADCAST_FILE" | sed -E 's|.*/([0-9]+)/run-latest\.json$|\1|')
+          echo "chain_id=$CHAIN_ID" >> $GITHUB_OUTPUT
+          echo "Deployed to chain ID: $CHAIN_ID"
+
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
+
+      - name: Resolve Blockscout URL from chain ID
+        id: network
+        run: |
+          CHAIN_ID="${{ steps.parse.outputs.chain_id }}"
+          CONFIG="${{ inputs.network-config-path }}"
+
+          # Search both testnets and mainnets arrays for a matching chain_id
+          BLOCKSCOUT_URL=$(jq -r --argjson cid "$CHAIN_ID" '
+            (.testnets // []) + (.mainnets // [])
+            | map(select(.chain_id == $cid))
+            | first
+            | .blockscout_url // empty
+          ' "$CONFIG" 2>/dev/null) || true
+
+          if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then
+            echo "::warning::No Blockscout URL found for chain ID $CHAIN_ID in $CONFIG. Falling back to testnets[0]."
+            BLOCKSCOUT_URL=$(jq -r '.testnets[0].blockscout_url' "$CONFIG")
+          fi
+
+          NETWORK_NAME=$(jq -r --argjson cid "$CHAIN_ID" '
+            (.testnets // []) + (.mainnets // [])
+            | map(select(.chain_id == $cid))
+            | first
+            | .name // "unknown"
+          ' "$CONFIG" 2>/dev/null) || NETWORK_NAME="unknown"
+
+          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
+          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
+          echo "Resolved Blockscout URL for chain $CHAIN_ID: $BLOCKSCOUT_URL ($NETWORK_NAME)"
 
       - name: Create deployment summary
         env:
@@ -490,16 +518,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Read network config
-        id: network
-        run: |
-          BLOCKSCOUT_URL=$(jq -r '.mainnets[0].blockscout_url' ${{ inputs.network-config-path }})
-          NETWORK_NAME=$(jq -r '.mainnets[0].name' ${{ inputs.network-config-path }})
-          ENVIRONMENT=$(jq -r '.mainnets[0].environment' ${{ inputs.network-config-path }})
-          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
-          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
-          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
-
       - name: Deploy contracts
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
@@ -526,7 +544,51 @@ jobs:
             exit 1
           fi
           echo "broadcast_file=$BROADCAST_FILE" >> $GITHUB_OUTPUT
+
+          # Extract the chain ID from the broadcast file path (broadcast/<script>/<chain_id>/run-latest.json)
+          CHAIN_ID=$(echo "$BROADCAST_FILE" | sed -E 's|.*/([0-9]+)/run-latest\.json$|\1|')
+          echo "chain_id=$CHAIN_ID" >> $GITHUB_OUTPUT
+          echo "Deployed to chain ID: $CHAIN_ID"
+
           jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
+
+      - name: Resolve Blockscout URL from chain ID
+        id: network
+        run: |
+          CHAIN_ID="${{ steps.parse.outputs.chain_id }}"
+          CONFIG="${{ inputs.network-config-path }}"
+
+          # Search both testnets and mainnets arrays for a matching chain_id
+          BLOCKSCOUT_URL=$(jq -r --argjson cid "$CHAIN_ID" '
+            (.testnets // []) + (.mainnets // [])
+            | map(select(.chain_id == $cid))
+            | first
+            | .blockscout_url // empty
+          ' "$CONFIG" 2>/dev/null) || true
+
+          if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then
+            echo "::warning::No Blockscout URL found for chain ID $CHAIN_ID in $CONFIG. Falling back to mainnets[0]."
+            BLOCKSCOUT_URL=$(jq -r '.mainnets[0].blockscout_url' "$CONFIG")
+          fi
+
+          NETWORK_NAME=$(jq -r --argjson cid "$CHAIN_ID" '
+            (.testnets // []) + (.mainnets // [])
+            | map(select(.chain_id == $cid))
+            | first
+            | .name // "unknown"
+          ' "$CONFIG" 2>/dev/null) || NETWORK_NAME="unknown"
+
+          ENVIRONMENT=$(jq -r --argjson cid "$CHAIN_ID" '
+            (.testnets // []) + (.mainnets // [])
+            | map(select(.chain_id == $cid))
+            | first
+            | .environment // "unknown"
+          ' "$CONFIG" 2>/dev/null) || ENVIRONMENT="unknown"
+
+          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
+          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
+          echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+          echo "Resolved Blockscout URL for chain $CHAIN_ID: $BLOCKSCOUT_URL ($NETWORK_NAME)"
 
       - name: Create deployment summary
         env:

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -457,45 +457,80 @@ jobs:
           fi
 
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
-          VERIFY_FAILED=0
 
+          # Collect all CREATE contracts
+          CONTRACTS=()
           while read -r tx; do
-            CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
-            CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
-            echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+            name=$(echo "$tx" | jq -r '.contractName')
+            addr=$(echo "$tx" | jq -r '.contractAddress')
+            CONTRACTS+=("${name}:${addr}")
+          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+
+          echo "Found ${#CONTRACTS[@]} contracts to verify"
+
+          # Phase 1: Submit all contracts for verification (no --watch)
+          for entry in "${CONTRACTS[@]}"; do
+            CONTRACT_NAME="${entry%%:*}"
+            CONTRACT_ADDR="${entry#*:}"
+            echo "Submitting $CONTRACT_NAME ($CONTRACT_ADDR) for verification..."
+            SUBMIT_OUTPUT=$(forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
+              --verifier blockscout \
+              --verifier-url "${BLOCKSCOUT_URL}/api" \
+              --guess-constructor-args 2>&1) || true
+            echo "$SUBMIT_OUTPUT"
+            if echo "$SUBMIT_OUTPUT" | grep -qi "already verified"; then
+              echo "  → already verified"
+            fi
+          done
+
+          # Phase 2: Wait for Blockscout to process the verification queue
+          echo "Waiting 60s for Blockscout to process submissions..."
+          sleep 60
+
+          # Phase 3: Check verification status via API, retry unverified contracts
+          VERIFY_FAILED=0
+          MAX_CHECKS=10
+          CHECK_DELAY=30
+
+          for entry in "${CONTRACTS[@]}"; do
+            CONTRACT_NAME="${entry%%:*}"
+            CONTRACT_ADDR="${entry#*:}"
+
             VERIFIED=0
-            for attempt in 1 2 3; do
-              VERIFY_OUTPUT=$(timeout 120 forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
-                --verifier blockscout \
-                --verifier-url "${BLOCKSCOUT_URL}/api" \
-                --guess-constructor-args \
-                --watch 2>&1) || true
-              echo "$VERIFY_OUTPUT"
-              if echo "$VERIFY_OUTPUT" | grep -qi "Contract successfully verified\|Pass - Verified"; then
-                echo "✓ Verified $CONTRACT_NAME"
+            for check in $(seq 1 $MAX_CHECKS); do
+              # Query Blockscout API for verification status
+              API_RESULT=$(curl -sf "${BLOCKSCOUT_URL}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
+              API_STATUS=$(echo "$API_RESULT" | jq -r '.status // "0"' 2>/dev/null) || API_STATUS="0"
+
+              if [[ "$API_STATUS" == "1" ]]; then
+                echo "✓ $CONTRACT_NAME ($CONTRACT_ADDR) verified"
                 VERIFIED=1
                 break
-              elif echo "$VERIFY_OUTPUT" | grep -qi "Already Verified"; then
-                echo "✓ $CONTRACT_NAME already verified"
-                VERIFIED=1
-                break
-              else
-                if [[ $attempt -lt 3 ]]; then
-                  echo "Attempt $attempt failed, retrying in $((attempt * 30))s..."
-                  sleep $((attempt * 30))
-                fi
+              fi
+
+              if [[ $check -lt $MAX_CHECKS ]]; then
+                echo "  $CONTRACT_NAME not yet verified (check $check/$MAX_CHECKS), resubmitting and waiting ${CHECK_DELAY}s..."
+                # Resubmit to ensure it's in the queue
+                forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
+                  --verifier blockscout \
+                  --verifier-url "${BLOCKSCOUT_URL}/api" \
+                  --guess-constructor-args 2>&1 || true
+                sleep $CHECK_DELAY
               fi
             done
+
             if [[ $VERIFIED -eq 0 ]]; then
-              echo "::error::Verification failed for $CONTRACT_NAME after 3 attempts"
+              echo "::error::Verification failed for $CONTRACT_NAME ($CONTRACT_ADDR) after $MAX_CHECKS checks"
               VERIFY_FAILED=1
             fi
-          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+          done
 
           if [[ $VERIFY_FAILED -eq 1 ]]; then
             echo "::error::One or more contracts failed verification"
             exit 1
           fi
+
+          echo "All contracts verified successfully"
 
   deploy-mainnet:
     name: Deploy Mainnet
@@ -622,45 +657,80 @@ jobs:
           fi
 
           BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
-          VERIFY_FAILED=0
 
+          # Collect all CREATE contracts
+          CONTRACTS=()
           while read -r tx; do
-            CONTRACT_NAME=$(echo "$tx" | jq -r '.contractName')
-            CONTRACT_ADDR=$(echo "$tx" | jq -r '.contractAddress')
-            echo "Verifying $CONTRACT_NAME at $CONTRACT_ADDR..."
+            name=$(echo "$tx" | jq -r '.contractName')
+            addr=$(echo "$tx" | jq -r '.contractAddress')
+            CONTRACTS+=("${name}:${addr}")
+          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+
+          echo "Found ${#CONTRACTS[@]} contracts to verify"
+
+          # Phase 1: Submit all contracts for verification (no --watch)
+          for entry in "${CONTRACTS[@]}"; do
+            CONTRACT_NAME="${entry%%:*}"
+            CONTRACT_ADDR="${entry#*:}"
+            echo "Submitting $CONTRACT_NAME ($CONTRACT_ADDR) for verification..."
+            SUBMIT_OUTPUT=$(forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
+              --verifier blockscout \
+              --verifier-url "${BLOCKSCOUT_URL}/api" \
+              --guess-constructor-args 2>&1) || true
+            echo "$SUBMIT_OUTPUT"
+            if echo "$SUBMIT_OUTPUT" | grep -qi "already verified"; then
+              echo "  → already verified"
+            fi
+          done
+
+          # Phase 2: Wait for Blockscout to process the verification queue
+          echo "Waiting 60s for Blockscout to process submissions..."
+          sleep 60
+
+          # Phase 3: Check verification status via API, retry unverified contracts
+          VERIFY_FAILED=0
+          MAX_CHECKS=10
+          CHECK_DELAY=30
+
+          for entry in "${CONTRACTS[@]}"; do
+            CONTRACT_NAME="${entry%%:*}"
+            CONTRACT_ADDR="${entry#*:}"
+
             VERIFIED=0
-            for attempt in 1 2 3; do
-              VERIFY_OUTPUT=$(timeout 120 forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
-                --verifier blockscout \
-                --verifier-url "${BLOCKSCOUT_URL}/api" \
-                --guess-constructor-args \
-                --watch 2>&1) || true
-              echo "$VERIFY_OUTPUT"
-              if echo "$VERIFY_OUTPUT" | grep -qi "Contract successfully verified\|Pass - Verified"; then
-                echo "✓ Verified $CONTRACT_NAME"
+            for check in $(seq 1 $MAX_CHECKS); do
+              # Query Blockscout API for verification status
+              API_RESULT=$(curl -sf "${BLOCKSCOUT_URL}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
+              API_STATUS=$(echo "$API_RESULT" | jq -r '.status // "0"' 2>/dev/null) || API_STATUS="0"
+
+              if [[ "$API_STATUS" == "1" ]]; then
+                echo "✓ $CONTRACT_NAME ($CONTRACT_ADDR) verified"
                 VERIFIED=1
                 break
-              elif echo "$VERIFY_OUTPUT" | grep -qi "Already Verified"; then
-                echo "✓ $CONTRACT_NAME already verified"
-                VERIFIED=1
-                break
-              else
-                if [[ $attempt -lt 3 ]]; then
-                  echo "Attempt $attempt failed, retrying in $((attempt * 30))s..."
-                  sleep $((attempt * 30))
-                fi
+              fi
+
+              if [[ $check -lt $MAX_CHECKS ]]; then
+                echo "  $CONTRACT_NAME not yet verified (check $check/$MAX_CHECKS), resubmitting and waiting ${CHECK_DELAY}s..."
+                # Resubmit to ensure it's in the queue
+                forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
+                  --verifier blockscout \
+                  --verifier-url "${BLOCKSCOUT_URL}/api" \
+                  --guess-constructor-args 2>&1 || true
+                sleep $CHECK_DELAY
               fi
             done
+
             if [[ $VERIFIED -eq 0 ]]; then
-              echo "::error::Verification failed for $CONTRACT_NAME after 3 attempts"
+              echo "::error::Verification failed for $CONTRACT_NAME ($CONTRACT_ADDR) after $MAX_CHECKS checks"
               VERIFY_FAILED=1
             fi
-          done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+          done
 
           if [[ $VERIFY_FAILED -eq 1 ]]; then
             echo "::error::One or more contracts failed verification"
             exit 1
           fi
+
+          echo "All contracts verified successfully"
 
   flatten-snapshots:
     name: Flatten Snapshots


### PR DESCRIPTION
## Summary

Two fixes for Blockscout contract verification failures:

### Fix 1: Resolve Blockscout URL from deployed chain ID
- The `deploy-testnet` and `deploy-mainnet` jobs hardcoded which Blockscout URL to use (`testnets[0]` vs `mainnets[0]`)
- When `RPC_URL` pointed to a different chain (e.g. Sepolia in the "mainnet" job), verification targeted the wrong Blockscout instance
- Now the chain ID is extracted from the broadcast file path and used to dynamically look up the correct Blockscout URL

### Fix 2: Rewrite verification to batch-submit then poll
- The old approach used `timeout 120 forge verify-contract --watch` per contract, which killed the command before Blockscout finished processing
- Contracts would silently get verified in the background but CI saw them as failures
- New approach:
  1. Submit all contracts for verification without `--watch` (fast)
  2. Wait 60s for Blockscout to process the batch
  3. Poll each contract's status via the Blockscout API (`getabi` endpoint)
  4. Resubmit + retry up to 10 times with 30s delays per contract

## Root cause

In `OpacityLabs/pilot-evm`:
1. **Chain mismatch**: `SEPOLIA_RPC_URL` passed as `RPC_URL` → deploys to Sepolia → verification hit mainnet Blockscout
2. **Timeout race**: `timeout 120` killed `forge verify-contract --watch` before Blockscout processed complex contracts like SecurityToken and TimelockBeacon

## Test plan

- [x] Chain ID resolution tested: correctly maps 11155111 → `eth-sepolia.blockscout.com`
- [ ] Batch verification approach tested on pilot-evm push to main
- [ ] All contracts verified successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)