### PR TITLE
feat: Node.js deps, RPC passthrough, coverage gating, Halmos, commitlint

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -13,6 +13,14 @@ on:
         description: 'Test verbosity level (v, vv, vvv, vvvv)'
         type: string
         default: 'vvv'
+      package-manager:
+        description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
+        type: string
+        default: 'none'
+      node-version:
+        description: 'Node.js version for package installation'
+        type: string
+        default: '20'
       run-slither:
         description: 'Run Slither static analysis'
         type: boolean
@@ -41,6 +49,22 @@ on:
         description: 'Post coverage summary as a sticky PR comment'
         type: boolean
         default: true
+      coverage-min-threshold:
+        description: 'Minimum coverage percentage to pass (0 = disabled)'
+        type: number
+        default: 0
+      run-halmos:
+        description: 'Run Halmos symbolic execution'
+        type: boolean
+        default: false
+      run-commitlint:
+        description: 'Enforce conventional commit messages'
+        type: boolean
+        default: false
+    secrets:
+      RPC_URL:
+        description: 'RPC endpoint for fork-based tests'
+        required: false
 
 jobs:
   check:
@@ -55,6 +79,22 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
+
       - name: Show Forge version
         run: forge --version
 
@@ -66,6 +106,8 @@ jobs:
         run: forge build
 
       - name: Run tests
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: forge test -${{ inputs.test-verbosity }}
 
   slither:
@@ -80,6 +122,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Build for Slither
         run: forge build --build-info --skip '*/test/**' '*/script/**' --force
@@ -104,10 +162,28 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
+
       - name: Show Forge version
         run: forge --version
 
       - name: Run coverage
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           if [[ -n "${{ inputs.coverage-exclude-paths }}" ]]; then
             forge coverage --no-match-path "${{ inputs.coverage-exclude-paths }}" 2>&1 | tee coverage-raw.txt
@@ -116,6 +192,7 @@ jobs:
           fi
 
       - name: Extract summary table
+        id: summary
         run: |
           # Extract the final summary table (box-drawing characters)
           awk '/^╭/,/^╰/' coverage-raw.txt > coverage-table.txt
@@ -142,6 +219,13 @@ jobs:
           done < src-rows.txt
 
           pct() { [ "$2" -eq 0 ] && echo "100.00% (0/0)" || printf "%.2f%% (%d/%d)" "$(echo "scale=4; $1 * 100 / $2" | bc)" "$1" "$2"; }
+
+          # Compute numeric percentages for threshold checking
+          num_pct() { [ "$2" -eq 0 ] && echo "100.00" || echo "scale=2; $1 * 100 / $2" | bc; }
+          echo "lines_pct=$(num_pct $total_lines_hit $total_lines_all)" >> $GITHUB_OUTPUT
+          echo "stmts_pct=$(num_pct $total_stmts_hit $total_stmts_all)" >> $GITHUB_OUTPUT
+          echo "branch_pct=$(num_pct $total_branch_hit $total_branch_all)" >> $GITHUB_OUTPUT
+          echo "funcs_pct=$(num_pct $total_funcs_hit $total_funcs_all)" >> $GITHUB_OUTPUT
 
           # Build the markdown comment
           {
@@ -175,3 +259,79 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: coverage-comment.md
+
+      - name: Check coverage threshold
+        if: inputs.coverage-min-threshold > 0
+        run: |
+          THRESHOLD=${{ inputs.coverage-min-threshold }}
+          FAILED=0
+          for metric in "Lines:${{ steps.summary.outputs.lines_pct }}" \
+                        "Statements:${{ steps.summary.outputs.stmts_pct }}" \
+                        "Branches:${{ steps.summary.outputs.branch_pct }}" \
+                        "Functions:${{ steps.summary.outputs.funcs_pct }}"; do
+            NAME="${metric%%:*}"
+            VALUE="${metric#*:}"
+            if (( $(echo "$VALUE < $THRESHOLD" | bc -l) )); then
+              echo "::error::$NAME coverage ($VALUE%) is below threshold ($THRESHOLD%)"
+              FAILED=1
+            fi
+          done
+          if [[ $FAILED -eq 1 ]]; then
+            exit 1
+          fi
+          echo "All coverage metrics meet the $THRESHOLD% threshold"
+
+  halmos:
+    name: Symbolic Execution
+    runs-on: ubuntu-latest
+    if: inputs.run-halmos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Halmos
+        run: pip install halmos
+
+      - name: Run Halmos
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
+        run: halmos
+
+  commitlint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    if: inputs.run-commitlint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/_deploy-mainnet.yml
+++ b/.github/workflows/_deploy-mainnet.yml
@@ -33,6 +33,14 @@ on:
         description: 'Path to store flattened contract snapshots'
         type: string
         default: 'test/upgrades'
+      package-manager:
+        description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
+        type: string
+        default: 'none'
+      node-version:
+        description: 'Node.js version for package installation'
+        type: string
+        default: '20'
     secrets:
       PRIVATE_KEY:
         required: true
@@ -80,6 +88,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Deploy contracts
         env:
@@ -219,6 +243,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Download all deployment artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -25,6 +25,14 @@ on:
         description: 'Verify deployed contracts on Blockscout'
         type: boolean
         default: true
+      package-manager:
+        description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
+        type: string
+        default: 'none'
+      node-version:
+        description: 'Node.js version for package installation'
+        type: string
+        default: '20'
     secrets:
       PRIVATE_KEY:
         required: true
@@ -46,6 +54,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Read network config
         id: network

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -31,6 +31,16 @@ on:
         type: string
         default: 'vvv'
 
+      # Node.js Dependency Options
+      package-manager:
+        description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
+        type: string
+        default: 'none'
+      node-version:
+        description: 'Node.js version for package installation'
+        type: string
+        default: '20'
+
       # Slither Options
       run-slither:
         description: 'Run Slither static analysis'
@@ -62,6 +72,10 @@ on:
         description: 'Post coverage summary as a sticky PR comment'
         type: boolean
         default: true
+      coverage-min-threshold:
+        description: 'Minimum coverage percentage to pass (0 = disabled)'
+        type: number
+        default: 0
 
       # Upgrade Safety Options
       run-upgrade-safety:
@@ -83,9 +97,13 @@ on:
         type: boolean
         default: false
       deploy-on-main:
-        description: 'Deploy to mainnet on push to main'
+        description: 'Deploy to mainnet on push to main branch'
         type: boolean
         default: false
+      main-branch:
+        description: 'Branch name that triggers mainnet deployment'
+        type: string
+        default: 'main'
       deploy-script:
         description: 'Path to deployment script'
         type: string
@@ -110,6 +128,18 @@ on:
         description: 'Path for flattened contract snapshots'
         type: string
         default: 'test/upgrades'
+
+      # Halmos Options
+      run-halmos:
+        description: 'Run Halmos symbolic execution'
+        type: boolean
+        default: false
+
+      # Commit Lint Options
+      run-commitlint:
+        description: 'Enforce conventional commit messages'
+        type: boolean
+        default: false
 
     secrets:
       PRIVATE_KEY:
@@ -179,6 +209,22 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
+
       - name: Show Forge version
         run: forge --version
 
@@ -190,6 +236,8 @@ jobs:
         run: forge build
 
       - name: Run tests
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: forge test -${{ inputs.test-verbosity }}
 
   slither:
@@ -207,6 +255,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Build for Slither
         run: forge build --build-info --skip '*/test/**' '*/script/**' --force
@@ -235,10 +299,28 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
+
       - name: Show Forge version
         run: forge --version
 
       - name: Run coverage
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
         run: |
           if [[ -n "${{ inputs.coverage-exclude-paths }}" ]]; then
             forge coverage --no-match-path "${{ inputs.coverage-exclude-paths }}" 2>&1 | tee coverage-raw.txt
@@ -247,6 +329,7 @@ jobs:
           fi
 
       - name: Extract summary table
+        id: summary
         run: |
           # Extract the final summary table (box-drawing characters)
           awk '/^╭/,/^╰/' coverage-raw.txt > coverage-table.txt
@@ -273,6 +356,13 @@ jobs:
           done < src-rows.txt
 
           pct() { [ "$2" -eq 0 ] && echo "100.00% (0/0)" || printf "%.2f%% (%d/%d)" "$(echo "scale=4; $1 * 100 / $2" | bc)" "$1" "$2"; }
+
+          # Compute numeric percentages for threshold checking
+          num_pct() { [ "$2" -eq 0 ] && echo "100.00" || echo "scale=2; $1 * 100 / $2" | bc; }
+          echo "lines_pct=$(num_pct $total_lines_hit $total_lines_all)" >> $GITHUB_OUTPUT
+          echo "stmts_pct=$(num_pct $total_stmts_hit $total_stmts_all)" >> $GITHUB_OUTPUT
+          echo "branch_pct=$(num_pct $total_branch_hit $total_branch_all)" >> $GITHUB_OUTPUT
+          echo "funcs_pct=$(num_pct $total_funcs_hit $total_funcs_all)" >> $GITHUB_OUTPUT
 
           # Build the markdown comment
           {
@@ -307,6 +397,85 @@ jobs:
         with:
           path: coverage-comment.md
 
+      - name: Check coverage threshold
+        if: inputs.coverage-min-threshold > 0
+        run: |
+          THRESHOLD=${{ inputs.coverage-min-threshold }}
+          FAILED=0
+          for metric in "Lines:${{ steps.summary.outputs.lines_pct }}" \
+                        "Statements:${{ steps.summary.outputs.stmts_pct }}" \
+                        "Branches:${{ steps.summary.outputs.branch_pct }}" \
+                        "Functions:${{ steps.summary.outputs.funcs_pct }}"; do
+            NAME="${metric%%:*}"
+            VALUE="${metric#*:}"
+            if (( $(echo "$VALUE < $THRESHOLD" | bc -l) )); then
+              echo "::error::$NAME coverage ($VALUE%) is below threshold ($THRESHOLD%)"
+              FAILED=1
+            fi
+          done
+          if [[ $FAILED -eq 1 ]]; then
+            exit 1
+          fi
+          echo "All coverage metrics meet the $THRESHOLD% threshold"
+
+  halmos:
+    name: Symbolic Execution
+    runs-on: ubuntu-latest
+    needs: [detect-changes]
+    if: |
+      needs.detect-changes.outputs.should-run == 'true' &&
+      inputs.run-halmos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Halmos
+        run: pip install halmos
+
+      - name: Run Halmos
+        env:
+          RPC_URL: ${{ secrets.RPC_URL }}
+        run: halmos
+
+  commitlint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    if: inputs.run-commitlint
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v5
+
   upgrade-safety:
     name: Upgrade Safety
     runs-on: ubuntu-latest
@@ -322,6 +491,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Run upgrade safety validation
         run: |
@@ -360,6 +545,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Deploy contracts
         env:
@@ -543,7 +744,7 @@ jobs:
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
       inputs.deploy-on-main &&
       github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
+      github.ref == format('refs/heads/{0}', inputs.main-branch)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -552,6 +753,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Deploy contracts
         env:
@@ -749,6 +966,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Build contracts
         run: forge build

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -17,6 +17,14 @@ on:
         description: 'Path to validation script'
         type: string
         default: 'script/upgrades/ValidateUpgrade.s.sol'
+      package-manager:
+        description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
+        type: string
+        default: 'none'
+      node-version:
+        description: 'Node.js version for package installation'
+        type: string
+        default: '20'
 
 jobs:
   upgrade-safety:
@@ -30,6 +38,22 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Node.js
+        if: inputs.package-manager != 'none'
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.package-manager }}
+
+      - name: Install dependencies
+        if: inputs.package-manager != 'none'
+        run: |
+          case "${{ inputs.package-manager }}" in
+            npm)  npm ci ;;
+            yarn) yarn --frozen-lockfile ;;
+            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          esac
 
       - name: Run upgrade safety validation
         run: |

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Reusable GitHub Actions workflows for Foundry smart contract CI/CD with upgrade 
 
 | Workflow | Description |
 |----------|-------------|
-| `_ci.yml` | Build, test, format check, and coverage report |
+| `_ci.yml` | Build, test, format check, coverage, Halmos, and commit lint |
 | `_upgrade-safety.yml` | OpenZeppelin upgrade safety validation |
 | `_deploy-testnet.yml` | Testnet deployment with Blockscout verification |
 | `_deploy-mainnet.yml` | Mainnet deployment with matrix support and 3-tier snapshot rotation |
+| `_foundry-cicd.yml` | All-in-one orchestrator combining all of the above |
 
 ## Usage
 
-Reference the reusable workflows in your Foundry project:
+### Basic CI
 
 ```yaml
 # .github/workflows/ci.yml
@@ -29,28 +30,10 @@ jobs:
       test-verbosity: 'vvv'
 ```
 
-```yaml
-# .github/workflows/deploy.yml
-name: Deploy
-
-on:
-  push:
-    branches: [main]
-
-jobs:
-  ci:
-    uses: BreadchainCoop/etherform/.github/workflows/_ci.yml@main
-
-  deploy:
-    needs: [ci]
-    uses: BreadchainCoop/etherform/.github/workflows/_deploy-mainnet.yml@main
-    secrets:
-      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      RPC_URL: ${{ secrets.RPC_URL }}
-```
+### CI with Node.js dependencies and fork-based tests
 
 ```yaml
-# .github/workflows/ci.yml (with coverage)
+# .github/workflows/ci.yml
 name: CI
 
 on: [push, pull_request]
@@ -63,9 +46,41 @@ jobs:
   ci:
     uses: BreadchainCoop/etherform/.github/workflows/_ci.yml@main
     with:
-      check-formatting: true
+      package-manager: yarn
       run-coverage: true
-      coverage-exclude-paths: 'test/fork/**'
+      coverage-min-threshold: 80
+      run-halmos: true
+      run-commitlint: true
+    secrets:
+      RPC_URL: ${{ secrets.RPC_URL }}
+```
+
+### Deploy pipeline
+
+```yaml
+# .github/workflows/deploy.yml
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    uses: BreadchainCoop/etherform/.github/workflows/_ci.yml@main
+    with:
+      package-manager: yarn
+    secrets:
+      RPC_URL: ${{ secrets.RPC_URL }}
+
+  deploy:
+    needs: [ci]
+    uses: BreadchainCoop/etherform/.github/workflows/_deploy-mainnet.yml@main
+    with:
+      package-manager: yarn
+    secrets:
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+      RPC_URL: ${{ secrets.RPC_URL }}
 ```
 
 ## Configuration
@@ -95,12 +110,19 @@ Create `.github/deploy-networks.json` in your repository:
 }
 ```
 
-### Secrets Required
+### Node.js Dependencies
 
-| Secret | Description |
-|--------|-------------|
-| `PRIVATE_KEY` | Deployer wallet private key |
-| `RPC_URL` | Network RPC endpoint |
+If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., OpenZeppelin via `node_modules`), set `package-manager` to your package manager. This installs Node.js and runs the appropriate install command before any `forge` operations.
+
+> **Note:** If using the `_foundry-cicd.yml` all-in-one workflow with `skip-if-no-changes: true`, add `package.json` and your lock file (e.g., `yarn.lock`) to the `contract-paths` input so dependency changes trigger the workflow.
+
+### Secrets
+
+| Secret | Used by | Description |
+|--------|---------|-------------|
+| `PRIVATE_KEY` | Deploy workflows | Deployer wallet private key |
+| `RPC_URL` | All workflows | Network RPC endpoint (also used for fork-based tests) |
+| `GH_TOKEN` | `_deploy-mainnet.yml` | GitHub token for pushing snapshot commits |
 
 ## Workflow Inputs
 
@@ -110,6 +132,8 @@ Create `.github/deploy-networks.json` in your repository:
 |-------|------|---------|-------------|
 | `check-formatting` | boolean | `true` | Run `forge fmt --check` |
 | `test-verbosity` | string | `'vvv'` | Test verbosity (`v`, `vv`, `vvv`, `vvvv`) |
+| `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
+| `node-version` | string | `'20'` | Node.js version for package installation |
 | `run-slither` | boolean | `false` | Run Slither static analysis |
 | `slither-fail-on` | string | `'high'` | Minimum severity to fail on (`low`, `medium`, `high`) |
 | `slither-config` | string | `'slither.config.json'` | Path to slither.config.json |
@@ -117,6 +141,13 @@ Create `.github/deploy-networks.json` in your repository:
 | `coverage-exclude-paths` | string | `''` | Path pattern to exclude from coverage (`--no-match-path`) |
 | `coverage-source-filter` | string | `' src/'` | Grep filter for source files in coverage report |
 | `coverage-post-comment` | boolean | `true` | Post coverage summary as a sticky PR comment |
+| `coverage-min-threshold` | number | `0` | Minimum coverage % to pass (0 = disabled) |
+| `run-halmos` | boolean | `false` | Run Halmos symbolic execution |
+| `run-commitlint` | boolean | `false` | Enforce conventional commit messages |
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `RPC_URL` | No | RPC endpoint for fork-based tests and coverage |
 
 > **Note:** When `run-coverage` and `coverage-post-comment` are enabled, the calling workflow must have `pull-requests: write` permission for the sticky comment to be posted.
 
@@ -127,6 +158,8 @@ Create `.github/deploy-networks.json` in your repository:
 | `baseline-path` | string | `'test/upgrades/baseline'` | Path to baseline contracts |
 | `fallback-path` | string | `'test/upgrades/previous'` | Fallback path if baseline missing |
 | `validation-script` | string | `'script/upgrades/ValidateUpgrade.s.sol'` | Validation script path |
+| `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
+| `node-version` | string | `'20'` | Node.js version for package installation |
 
 ### `_deploy-testnet.yml`
 
@@ -136,6 +169,9 @@ Create `.github/deploy-networks.json` in your repository:
 | `network-config-path` | string | `'.github/deploy-networks.json'` | Network config path |
 | `network-index` | number | `0` | Index in testnets array |
 | `indexing-wait` | number | `60` | Seconds to wait before verification |
+| `verify-contracts` | boolean | `true` | Verify on Blockscout |
+| `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
+| `node-version` | string | `'20'` | Node.js version for package installation |
 
 ### `_deploy-mainnet.yml`
 
@@ -145,8 +181,23 @@ Create `.github/deploy-networks.json` in your repository:
 | `network-config-path` | string | `'.github/deploy-networks.json'` | Network config path |
 | `network` | string | `''` | Specific network (empty = all) |
 | `indexing-wait` | number | `60` | Seconds to wait before verification |
+| `verify-contracts` | boolean | `true` | Verify on Blockscout |
 | `flatten-contracts` | boolean | `true` | Flatten and commit snapshots |
 | `upgrades-path` | string | `'test/upgrades'` | Path for flattened snapshots |
+| `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
+| `node-version` | string | `'20'` | Node.js version for package installation |
+
+### `_foundry-cicd.yml`
+
+The all-in-one workflow accepts all inputs from the above workflows plus:
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `skip-if-no-changes` | boolean | `true` | Skip if no contract files changed |
+| `contract-paths` | string | `src/**`, `script/**`, etc. | Paths to watch for changes |
+| `main-branch` | string | `'main'` | Branch that triggers mainnet deployment |
+| `deploy-on-pr` | boolean | `false` | Deploy to testnet on PR |
+| `deploy-on-main` | boolean | `false` | Deploy to mainnet on push |
 
 ## Example Project
 


### PR DESCRIPTION
## Summary

Adds 6 features driven by saving-circles adoption needs:

- **Node.js dependency support** (`package-manager` input) across all 5 workflow files — supports npm, yarn, and pnpm with frozen lockfiles
- **RPC secret passthrough** to CI test and coverage jobs — enables fork-based integration tests
- **Coverage minimum threshold** (`coverage-min-threshold`) — fails the build if any metric drops below the threshold
- **Configurable deploy branch** (`main-branch`) — supports teams using `dev`, `develop`, etc. instead of `main`
- **Halmos symbolic execution** (`run-halmos`) — optional formal verification job with Python 3.12 + Halmos
- **Conventional commit linting** (`run-commitlint`) — optional enforcement via wagoid/commitlint-github-action

All features are opt-in with backwards-compatible defaults. Existing consumers are unaffected.

## Test plan

- [ ] Verify YAML syntax passes (validated locally with Ruby YAML parser)
- [ ] Test `package-manager: yarn` with saving-circles repo
- [ ] Test `RPC_URL` secret flows to `forge test` in CI job
- [ ] Test `coverage-min-threshold` fails build when coverage is below threshold
- [ ] Test `main-branch: dev` triggers mainnet deploy on push to dev
- [ ] Test `run-halmos: true` installs and runs Halmos
- [ ] Test `run-commitlint: true` validates commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)