### PR TITLE
feat: separate contract verification job from deployment

### DIFF
--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -53,6 +53,7 @@ jobs:
     outputs:
       network_name: ${{ steps.network.outputs.network_name }}
       blockscout_url: ${{ steps.network.outputs.blockscout_url }}
+      broadcast_file: ${{ steps.parse.outputs.broadcast_file }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -127,16 +128,49 @@ jobs:
           name: deployment-${{ steps.network.outputs.network_name }}
           path: deployments/
 
+      - name: Upload broadcast artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: broadcast
+          path: broadcast/
+
       - name: Create deployment summary
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
           SUMMARY_TITLE: Testnet Deployment Summary
         run: bash .etherform/scripts/deploy/deployment-summary.sh
 
+  verify-contracts:
+    name: Verify Contracts
+    runs-on: ubuntu-latest
+    needs: [deploy-testnet]
+    if: inputs.verify-contracts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout etherform scripts
+        uses: actions/checkout@v4
+        with:
+          repository: BreadchainCoop/etherform
+          ref: ${{ inputs.etherform-ref }}
+          path: .etherform
+          sparse-checkout: scripts
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Download broadcast artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: broadcast
+          path: broadcast/
+
       - name: Verify contracts on Blockscout
-        if: inputs.verify-contracts
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.deploy-testnet.outputs.blockscout_url }}
           ETH_RPC_URL: ${{ secrets.RPC_URL }}
-          BROADCAST_FILE: ${{ steps.parse.outputs.broadcast_file }}
+          BROADCAST_FILE: ${{ needs.deploy-testnet.outputs.broadcast_file }}
         run: bash .etherform/scripts/deploy/verify-blockscout.sh

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -454,6 +454,9 @@ jobs:
       (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
       inputs.deploy-on-pr &&
       github.event_name == 'pull_request'
+    outputs:
+      blockscout_url: ${{ steps.network.outputs.blockscout_url }}
+      broadcast_file: ${{ steps.parse.outputs.broadcast_file }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -508,6 +511,12 @@ jobs:
         id: parse
         run: bash .etherform/scripts/deploy/parse-broadcast.sh
 
+      - name: Upload broadcast artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: broadcast
+          path: broadcast/
+
       - name: Resolve Blockscout URL from chain ID
         id: network
         env:
@@ -521,10 +530,40 @@ jobs:
           SUMMARY_TITLE: Testnet Deployment Summary
         run: bash .etherform/scripts/deploy/deployment-summary.sh
 
+  verify-contracts:
+    name: Verify Contracts
+    runs-on: ubuntu-latest
+    needs: [deploy-testnet]
+    if: |
+      always() &&
+      needs.deploy-testnet.result == 'success' &&
+      inputs.verify-contracts
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout etherform scripts
+        uses: actions/checkout@v4
+        with:
+          repository: BreadchainCoop/etherform
+          ref: ${{ inputs.etherform-ref }}
+          path: .etherform
+          sparse-checkout: scripts
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Download broadcast artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: broadcast
+          path: broadcast/
+
       - name: Verify contracts on Blockscout
-        if: inputs.verify-contracts
         env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.deploy-testnet.outputs.blockscout_url }}
           ETH_RPC_URL: ${{ secrets.RPC_URL }}
-          BROADCAST_FILE: ${{ steps.parse.outputs.broadcast_file }}
+          BROADCAST_FILE: ${{ needs.deploy-testnet.outputs.broadcast_file }}
         run: bash .etherform/scripts/deploy/verify-blockscout.sh


### PR DESCRIPTION
#27

context: this was in draft because it was based on the big refactor that moved everything into scripts, since then the refactor was merged so it's ready for review

motivation TL;DR - if the verification fails it doesn't show the deployment job as failed