### PR TITLE
fix: harden deploy scripts and upgrade safety workflows

### DIFF
--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -409,20 +409,14 @@ jobs:
           path: .etherform
           sparse-checkout: scripts
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Setup Node.js
-        if: inputs.package-manager != 'none'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
+          cache: ${{ inputs.package-manager != 'none' && inputs.package-manager || '' }}
 
       - name: Install dependencies
         if: inputs.package-manager != 'none'
@@ -451,7 +445,7 @@ jobs:
       always() &&
       needs.detect-changes.outputs.should-run == 'true' &&
       needs.ci.result == 'success' &&
-      (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
+      needs.upgrade-safety.result == 'success' &&
       inputs.deploy-on-pr &&
       github.event_name == 'pull_request'
     steps:
@@ -494,7 +488,7 @@ jobs:
           DEPLOY_ENV_VARS: ${{ secrets.DEPLOY_ENV_VARS }}
         run: |
           source .etherform/scripts/deploy/prepare-env.sh
-          forge script ${{ inputs.deploy-script }} \
+          forge script "${{ inputs.deploy-script }}" \
             --rpc-url "$RPC_URL" \
             --private-key "$PRIVATE_KEY" \
             --broadcast \

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -78,10 +78,6 @@ on:
         default: 0
 
       # Upgrade Safety Options
-      run-upgrade-safety:
-        description: 'Run upgrade safety validation'
-        type: boolean
-        default: true
       upgrades-config:
         description: 'Path to upgrade safety configuration (upgrades.json)'
         type: string
@@ -391,9 +387,7 @@ jobs:
     name: Upgrade Safety
     runs-on: ubuntu-latest
     needs: [detect-changes, ci]
-    if: |
-      needs.detect-changes.outputs.should-run == 'true' &&
-      inputs.run-upgrade-safety
+    if: needs.detect-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -416,7 +410,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager != 'none' && inputs.package-manager || '' }}
+          cache: ${{ inputs.package-manager }}
 
       - name: Install dependencies
         if: inputs.package-manager != 'none'
@@ -429,6 +423,12 @@ jobs:
 
       - name: Build contracts
         run: forge build --build-info --extra-output storageLayout
+
+      - name: Validate upgrades config
+        env:
+          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
+          BASE_BRANCH: ${{ inputs.main-branch }}
+        run: bash .etherform/scripts/upgrade-safety/validate-config.sh
 
       - name: Validate upgrade safety
         env:

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -52,20 +52,14 @@ jobs:
           path: .etherform
           sparse-checkout: scripts
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Setup Node.js
-        if: inputs.package-manager != 'none'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
+          cache: ${{ inputs.package-manager != 'none' && inputs.package-manager || '' }}
 
       - name: Install dependencies
         if: inputs.package-manager != 'none'

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager != 'none' && inputs.package-manager || '' }}
+          cache: ${{ inputs.package-manager }}
 
       - name: Install dependencies
         if: inputs.package-manager != 'none'
@@ -72,6 +72,12 @@ jobs:
 
       - name: Build contracts
         run: forge build --build-info --extra-output storageLayout
+
+      - name: Validate upgrades config
+        env:
+          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: bash .etherform/scripts/upgrade-safety/validate-config.sh
 
       - name: Validate upgrade safety
         env:

--- a/scripts/deploy/prepare-env.sh
+++ b/scripts/deploy/prepare-env.sh
@@ -17,7 +17,7 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
     # Expect KEY=VALUE; fail on malformed lines
     if [[ "$line" != *=* ]]; then
       echo "::error::Malformed DEPLOY_ENV_VARS line (no '='): $line"
-      return 1 2>/dev/null || exit 1
+      return 1
     fi
 
     key=${line%%=*}
@@ -26,7 +26,7 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
     # Validate KEY against a safe variable-name pattern
     if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
       echo "::error::Invalid variable name in DEPLOY_ENV_VARS: $key"
-      return 1 2>/dev/null || exit 1
+      return 1
     fi
 
     export "$key=$value"

--- a/scripts/deploy/prepare-env.sh
+++ b/scripts/deploy/prepare-env.sh
@@ -14,9 +14,10 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
   while IFS= read -r line; do
     [[ -z "$line" || "$line" == \#* ]] && continue
 
-    # Expect KEY=VALUE; skip malformed lines
+    # Expect KEY=VALUE; fail on malformed lines
     if [[ "$line" != *=* ]]; then
-      continue
+      echo "::error::Malformed DEPLOY_ENV_VARS line (no '='): $line"
+      return 1 2>/dev/null || exit 1
     fi
 
     key=${line%%=*}
@@ -24,7 +25,8 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
 
     # Validate KEY against a safe variable-name pattern
     if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-      continue
+      echo "::error::Invalid variable name in DEPLOY_ENV_VARS: $key"
+      return 1 2>/dev/null || exit 1
     fi
 
     export "$key=$value"

--- a/scripts/deploy/prepare-env.sh
+++ b/scripts/deploy/prepare-env.sh
@@ -13,6 +13,20 @@ fi
 if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
   while IFS= read -r line; do
     [[ -z "$line" || "$line" == \#* ]] && continue
-    export "${line?}"
+
+    # Expect KEY=VALUE; skip malformed lines
+    if [[ "$line" != *=* ]]; then
+      continue
+    fi
+
+    key=${line%%=*}
+    value=${line#*=}
+
+    # Validate KEY against a safe variable-name pattern
+    if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      continue
+    fi
+
+    export "$key=$value"
   done <<< "$DEPLOY_ENV_VARS"
 fi

--- a/scripts/deploy/resolve-network.sh
+++ b/scripts/deploy/resolve-network.sh
@@ -27,6 +27,12 @@ if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" ]]; then
   BLOCKSCOUT_URL=$(jq -r '.testnets[0].blockscout_url' "$NETWORK_CONFIG")
 fi
 
+# Post-fallback validation: ensure we have a non-empty, HTTP(S) Blockscout URL
+if [[ -z "$BLOCKSCOUT_URL" || "$BLOCKSCOUT_URL" == "null" || ! "$BLOCKSCOUT_URL" =~ ^https?:// ]]; then
+  echo "::error::No valid blockscout_url found in $NETWORK_CONFIG"
+  exit 1
+fi
+
 NETWORK_NAME=$(jq -r --argjson cid "$CHAIN_ID" '
   (.testnets // [])
   | map(select(.chain_id == $cid))

--- a/scripts/deploy/verify-blockscout.sh
+++ b/scripts/deploy/verify-blockscout.sh
@@ -27,6 +27,9 @@ if [[ ! "$BLOCKSCOUT_URL" =~ ^https?:// ]]; then
   exit 1
 fi
 
+# Normalize URL once (strip trailing slash) to avoid double-slash in API calls
+BLOCKSCOUT_URL="${BLOCKSCOUT_URL%/}"
+
 # Collect all CREATE contracts
 CONTRACTS=()
 while read -r tx; do
@@ -66,7 +69,7 @@ for entry in "${CONTRACTS[@]}"; do
   VERIFIED=0
   for check in $(seq 1 "$MAX_CHECKS"); do
     # Query Blockscout API for verification status
-    API_RESULT=$(curl -sf --connect-timeout 10 --max-time 30 "${BLOCKSCOUT_URL%/}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
+    API_RESULT=$(curl -sf --connect-timeout 10 --max-time 30 "${BLOCKSCOUT_URL}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
     API_STATUS=$(echo "$API_RESULT" | jq -r '.status // "0"' 2>/dev/null) || API_STATUS="0"
 
     if [[ "$API_STATUS" == "1" ]]; then

--- a/scripts/deploy/verify-blockscout.sh
+++ b/scripts/deploy/verify-blockscout.sh
@@ -66,7 +66,7 @@ for entry in "${CONTRACTS[@]}"; do
   VERIFIED=0
   for check in $(seq 1 "$MAX_CHECKS"); do
     # Query Blockscout API for verification status
-    API_RESULT=$(curl -sf "${BLOCKSCOUT_URL}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
+    API_RESULT=$(curl -sf --connect-timeout 10 --max-time 30 "${BLOCKSCOUT_URL%/}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
     API_STATUS=$(echo "$API_RESULT" | jq -r '.status // "0"' 2>/dev/null) || API_STATUS="0"
 
     if [[ "$API_STATUS" == "1" ]]; then

--- a/scripts/upgrade-safety/validate-config.sh
+++ b/scripts/upgrade-safety/validate-config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Validate that no contracts were removed from the upgrades config compared to the base branch.
+# Compares by .contract field only. Prevents bypassing upgrade safety by removing entries.
+#
+# Env inputs:
+#   UPGRADES_CONFIG   — required, path to upgrades.json
+#   BASE_BRANCH       — required, branch name to compare against
+
+: "${UPGRADES_CONFIG:?UPGRADES_CONFIG is required}"
+: "${BASE_BRANCH:?BASE_BRANCH is required}"
+
+if [[ ! -f "$UPGRADES_CONFIG" ]]; then
+  echo "::error::No upgrades config found at $UPGRADES_CONFIG"
+  exit 1
+fi
+
+# Fetch the base branch
+if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
+  echo "::error::Failed to fetch base branch $BASE_BRANCH — cannot validate config changes"
+  exit 1
+fi
+
+# Read base branch config
+if ! git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" > /dev/null 2>&1; then
+  echo "No $UPGRADES_CONFIG on base branch — nothing to compare against"
+  exit 0
+fi
+
+BASE_CONFIG=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}") || {
+  echo "::error::Failed to read $UPGRADES_CONFIG from base branch $BASE_BRANCH"
+  exit 1
+}
+
+CURRENT_CONTRACTS=$(jq -r '[.contracts[].contract]' "$UPGRADES_CONFIG")
+BASE_CONTRACTS=$(echo "$BASE_CONFIG" | jq -r '[.contracts[].contract]')
+
+# Find base branch contracts missing from current config
+REMOVED=$(jq -n --argjson base "$BASE_CONTRACTS" --argjson current "$CURRENT_CONTRACTS" \
+  '[$base[] | select(. as $b | $current | index($b) | not)]')
+
+REMOVED_COUNT=$(echo "$REMOVED" | jq 'length')
+
+if [[ "$REMOVED_COUNT" -gt 0 ]]; then
+  REMOVED_LIST=$(echo "$REMOVED" | jq -r '.[]')
+  echo "::error::$REMOVED_COUNT contract(s) removed from $UPGRADES_CONFIG compared to base branch ($BASE_BRANCH):"
+  echo "$REMOVED_LIST"
+  {
+    echo "## Upgrade Config Validation"
+    echo ""
+    echo "> **Error:** $REMOVED_COUNT contract(s) were removed from \`$UPGRADES_CONFIG\`:"
+    echo ""
+    echo "$REMOVED_LIST" | while read -r c; do echo "- \`$c\`"; done
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 1
+fi
+
+CURRENT_COUNT=$(echo "$CURRENT_CONTRACTS" | jq 'length')
+BASE_COUNT=$(echo "$BASE_CONTRACTS" | jq 'length')
+echo "Config validation passed: $CURRENT_COUNT contracts (base branch has $BASE_COUNT)"

--- a/scripts/upgrade-safety/validate.sh
+++ b/scripts/upgrade-safety/validate.sh
@@ -42,10 +42,49 @@ fi
 # Check for empty contracts array — fail if base branch has entries (prevents bypass via emptying the config)
 CONTRACT_COUNT=$(jq '.contracts | length' "$UPGRADES_CONFIG")
 if [[ "$CONTRACT_COUNT" -eq 0 ]]; then
-  git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+  # Ensure we can access the base branch; fail hard unless ALLOW_FALLBACK=true
+  if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
+    if [[ "$ALLOW_FALLBACK" != "true" ]]; then
+      echo "::error::Failed to fetch base branch $BASE_BRANCH — cannot safely validate empty contracts configuration"
+      {
+        echo "## Upgrade Safety Validation"
+        echo ""
+        echo "> **Error:** Failed to fetch base branch \`$BASE_BRANCH\`. Cannot determine previous contracts to validate an empty \`$UPGRADES_CONFIG\`."
+      } >> "$GITHUB_STEP_SUMMARY"
+      exit 1
+    else
+      echo "::warning::Failed to fetch base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
+    fi
+  fi
+
   BASE_CONTRACT_COUNT=0
   if git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" > /dev/null 2>&1; then
-    BASE_CONTRACT_COUNT=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" | jq '.contracts | length' 2>/dev/null) || BASE_CONTRACT_COUNT=0
+    if ! BASE_CONTRACT_COUNT=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" | jq '.contracts | length' 2>/dev/null); then
+      if [[ "$ALLOW_FALLBACK" != "true" ]]; then
+        echo "::error::Failed to parse contracts from $UPGRADES_CONFIG on base branch $BASE_BRANCH"
+        {
+          echo "## Upgrade Safety Validation"
+          echo ""
+          echo "> **Error:** Could not parse contracts from \`$UPGRADES_CONFIG\` on base branch \`$BASE_BRANCH\`. Cannot safely validate an empty config."
+        } >> "$GITHUB_STEP_SUMMARY"
+        exit 1
+      else
+        echo "::warning::Failed to parse contracts from $UPGRADES_CONFIG on base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
+        BASE_CONTRACT_COUNT=0
+      fi
+    fi
+  else
+    if [[ "$ALLOW_FALLBACK" != "true" ]]; then
+      echo "::error::Unable to read $UPGRADES_CONFIG from base branch $BASE_BRANCH — cannot safely validate empty contracts configuration"
+      {
+        echo "## Upgrade Safety Validation"
+        echo ""
+        echo "> **Error:** Could not read \`$UPGRADES_CONFIG\` from base branch \`$BASE_BRANCH\`. Cannot determine previous contracts to validate an empty config."
+      } >> "$GITHUB_STEP_SUMMARY"
+      exit 1
+    else
+      echo "::warning::Unable to read $UPGRADES_CONFIG from base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
+    fi
   fi
 
   if [[ "$BASE_CONTRACT_COUNT" -gt 0 ]]; then

--- a/scripts/upgrade-safety/validate.sh
+++ b/scripts/upgrade-safety/validate.sh
@@ -14,7 +14,6 @@ set -euo pipefail
 : "${BASE_BRANCH:?BASE_BRANCH is required}"
 : "${PACKAGE_MANAGER:?PACKAGE_MANAGER is required}"
 CURRENT_BUILD="${CURRENT_BUILD:-out/build-info}"
-ALLOW_FALLBACK="${ALLOW_FALLBACK:-false}"
 OZ_UPGRADES_CORE_VERSION="${OZ_UPGRADES_CORE_VERSION:-1.44.2}"
 
 # Check if config exists
@@ -39,64 +38,9 @@ if ! jq -e 'has("contracts")' "$UPGRADES_CONFIG" > /dev/null 2>&1; then
   exit 1
 fi
 
-# Check for empty contracts array — fail if base branch has entries (prevents bypass via emptying the config)
+# Check for empty contracts array
 CONTRACT_COUNT=$(jq '.contracts | length' "$UPGRADES_CONFIG")
 if [[ "$CONTRACT_COUNT" -eq 0 ]]; then
-  # Ensure we can access the base branch; fail hard unless ALLOW_FALLBACK=true
-  if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
-    if [[ "$ALLOW_FALLBACK" != "true" ]]; then
-      echo "::error::Failed to fetch base branch $BASE_BRANCH — cannot safely validate empty contracts configuration"
-      {
-        echo "## Upgrade Safety Validation"
-        echo ""
-        echo "> **Error:** Failed to fetch base branch \`$BASE_BRANCH\`. Cannot determine previous contracts to validate an empty \`$UPGRADES_CONFIG\`."
-      } >> "$GITHUB_STEP_SUMMARY"
-      exit 1
-    else
-      echo "::warning::Failed to fetch base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
-    fi
-  fi
-
-  BASE_CONTRACT_COUNT=0
-  if git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" > /dev/null 2>&1; then
-    if ! BASE_CONTRACT_COUNT=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" | jq '.contracts | length' 2>/dev/null); then
-      if [[ "$ALLOW_FALLBACK" != "true" ]]; then
-        echo "::error::Failed to parse contracts from $UPGRADES_CONFIG on base branch $BASE_BRANCH"
-        {
-          echo "## Upgrade Safety Validation"
-          echo ""
-          echo "> **Error:** Could not parse contracts from \`$UPGRADES_CONFIG\` on base branch \`$BASE_BRANCH\`. Cannot safely validate an empty config."
-        } >> "$GITHUB_STEP_SUMMARY"
-        exit 1
-      else
-        echo "::warning::Failed to parse contracts from $UPGRADES_CONFIG on base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
-        BASE_CONTRACT_COUNT=0
-      fi
-    fi
-  else
-    if [[ "$ALLOW_FALLBACK" != "true" ]]; then
-      echo "::error::Unable to read $UPGRADES_CONFIG from base branch $BASE_BRANCH — cannot safely validate empty contracts configuration"
-      {
-        echo "## Upgrade Safety Validation"
-        echo ""
-        echo "> **Error:** Could not read \`$UPGRADES_CONFIG\` from base branch \`$BASE_BRANCH\`. Cannot determine previous contracts to validate an empty config."
-      } >> "$GITHUB_STEP_SUMMARY"
-      exit 1
-    else
-      echo "::warning::Unable to read $UPGRADES_CONFIG from base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
-    fi
-  fi
-
-  if [[ "$BASE_CONTRACT_COUNT" -gt 0 ]]; then
-    echo "::error::$UPGRADES_CONFIG has 0 contracts but base branch ($BASE_BRANCH) has $BASE_CONTRACT_COUNT — refusing to skip validation"
-    {
-      echo "## Upgrade Safety Validation"
-      echo ""
-      echo "> **Error:** \`$UPGRADES_CONFIG\` has no contracts, but the base branch has $BASE_CONTRACT_COUNT. This looks like an attempt to bypass validation."
-    } >> "$GITHUB_STEP_SUMMARY"
-    exit 1
-  fi
-
   echo "::warning::No contracts defined in $UPGRADES_CONFIG — skipping upgrade safety validation"
   {
     echo "## Upgrade Safety Validation"
@@ -121,7 +65,10 @@ BASE_BUILD=""
 BASE_DIR=""
 if [[ "$NEEDS_BASE" == "true" ]]; then
   echo "Building base branch ($BASE_BRANCH) for comparison..."
-  git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+  if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
+    echo "::error::Failed to fetch base branch $BASE_BRANCH — required for contracts without explicit reference"
+    exit 1
+  fi
   BASE_DIR=$(mktemp -d)
 
   if git worktree add --detach "$BASE_DIR" "origin/$BASE_BRANCH" 2>/dev/null; then
@@ -141,20 +88,12 @@ if [[ "$NEEDS_BASE" == "true" ]]; then
       BASE_BUILD="${BASE_DIR}/out/base-build-info"
       echo "Base branch built successfully"
     else
-      if [[ "$ALLOW_FALLBACK" == "true" ]]; then
-        echo "::warning::Failed to build base branch — contracts without explicit reference will be validated for upgradeability only (ALLOW_FALLBACK=true)"
-      else
-        echo "::error::Failed to build base branch. Set ALLOW_FALLBACK=true to downgrade to upgradeability-only validation."
-        exit 1
-      fi
-    fi
-  else
-    if [[ "$ALLOW_FALLBACK" == "true" ]]; then
-      echo "::warning::Could not checkout base branch '$BASE_BRANCH' — contracts without explicit reference will be validated for upgradeability only (ALLOW_FALLBACK=true)"
-    else
-      echo "::error::Could not checkout base branch '$BASE_BRANCH'. Set ALLOW_FALLBACK=true to downgrade to upgradeability-only validation."
+      echo "::error::Failed to build base branch — required for contracts without explicit reference"
       exit 1
     fi
+  else
+    echo "::error::Could not checkout base branch '$BASE_BRANCH' — required for contracts without explicit reference"
+    exit 1
   fi
 fi
 

--- a/scripts/upgrade-safety/validate.sh
+++ b/scripts/upgrade-safety/validate.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 : "${BASE_BRANCH:?BASE_BRANCH is required}"
 : "${PACKAGE_MANAGER:?PACKAGE_MANAGER is required}"
 CURRENT_BUILD="${CURRENT_BUILD:-out/build-info}"
+ALLOW_FALLBACK="${ALLOW_FALLBACK:-false}"
+OZ_UPGRADES_CORE_VERSION="${OZ_UPGRADES_CORE_VERSION:-1.44.2}"
 
 # Check if config exists
 if [[ ! -f "$UPGRADES_CONFIG" ]]; then
@@ -37,9 +39,25 @@ if ! jq -e 'has("contracts")' "$UPGRADES_CONFIG" > /dev/null 2>&1; then
   exit 1
 fi
 
-# Check for empty contracts array
+# Check for empty contracts array — fail if base branch has entries (prevents bypass via emptying the config)
 CONTRACT_COUNT=$(jq '.contracts | length' "$UPGRADES_CONFIG")
 if [[ "$CONTRACT_COUNT" -eq 0 ]]; then
+  git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+  BASE_CONTRACT_COUNT=0
+  if git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" > /dev/null 2>&1; then
+    BASE_CONTRACT_COUNT=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" | jq '.contracts | length' 2>/dev/null) || BASE_CONTRACT_COUNT=0
+  fi
+
+  if [[ "$BASE_CONTRACT_COUNT" -gt 0 ]]; then
+    echo "::error::$UPGRADES_CONFIG has 0 contracts but base branch ($BASE_BRANCH) has $BASE_CONTRACT_COUNT — refusing to skip validation"
+    {
+      echo "## Upgrade Safety Validation"
+      echo ""
+      echo "> **Error:** \`$UPGRADES_CONFIG\` has no contracts, but the base branch has $BASE_CONTRACT_COUNT. This looks like an attempt to bypass validation."
+    } >> "$GITHUB_STEP_SUMMARY"
+    exit 1
+  fi
+
   echo "::warning::No contracts defined in $UPGRADES_CONFIG — skipping upgrade safety validation"
   {
     echo "## Upgrade Safety Validation"
@@ -84,10 +102,20 @@ if [[ "$NEEDS_BASE" == "true" ]]; then
       BASE_BUILD="${BASE_DIR}/out/base-build-info"
       echo "Base branch built successfully"
     else
-      echo "::warning::Failed to build base branch — contracts without explicit reference will be validated for upgradeability only"
+      if [[ "$ALLOW_FALLBACK" == "true" ]]; then
+        echo "::warning::Failed to build base branch — contracts without explicit reference will be validated for upgradeability only (ALLOW_FALLBACK=true)"
+      else
+        echo "::error::Failed to build base branch. Set ALLOW_FALLBACK=true to downgrade to upgradeability-only validation."
+        exit 1
+      fi
     fi
   else
-    echo "::warning::Could not checkout base branch '$BASE_BRANCH' — contracts without explicit reference will be validated for upgradeability only"
+    if [[ "$ALLOW_FALLBACK" == "true" ]]; then
+      echo "::warning::Could not checkout base branch '$BASE_BRANCH' — contracts without explicit reference will be validated for upgradeability only (ALLOW_FALLBACK=true)"
+    else
+      echo "::error::Could not checkout base branch '$BASE_BRANCH'. Set ALLOW_FALLBACK=true to downgrade to upgradeability-only validation."
+      exit 1
+    fi
   fi
 fi
 
@@ -107,7 +135,7 @@ while IFS= read -r entry; do
     # === Base branch comparison (default) ===
     if [[ -n "$BASE_BUILD" ]] && git show "origin/${BASE_BRANCH}:${CONTRACT_PATH}" > /dev/null 2>&1; then
       # Contract exists on base branch — compare storage layouts
-      if OUTPUT=$(npx @openzeppelin/upgrades-core validate "$CURRENT_BUILD" \
+      if OUTPUT=$(npx @openzeppelin/upgrades-core@"$OZ_UPGRADES_CORE_VERSION" validate "$CURRENT_BUILD" \
           --contract "$CONTRACT" \
           --reference "base-build-info:${CONTRACT}" \
           --referenceBuildInfoDirs "$BASE_BUILD" 2>&1); then
@@ -122,7 +150,7 @@ while IFS= read -r entry; do
     else
       # Contract doesn't exist on base branch or base build failed — validate upgradeability only
       echo "Contract not found on $BASE_BRANCH or base build unavailable, validating upgradeability only..."
-      if OUTPUT=$(npx @openzeppelin/upgrades-core validate "$CURRENT_BUILD" \
+      if OUTPUT=$(npx @openzeppelin/upgrades-core@"$OZ_UPGRADES_CORE_VERSION" validate "$CURRENT_BUILD" \
           --contract "$CONTRACT" 2>&1); then
         echo "$OUTPUT"
         SUMMARY="${SUMMARY}| \`${CONTRACT}\` | (new contract) | Pass |"$'\n'
@@ -137,7 +165,7 @@ while IFS= read -r entry; do
   elif echo "$REF_VALUE" | jq -e 'type == "string"' > /dev/null 2>&1; then
     # === Contract qualifier reference ===
     QUALIFIER=$(echo "$entry" | jq -r '.reference')
-    if OUTPUT=$(npx @openzeppelin/upgrades-core validate "$CURRENT_BUILD" \
+    if OUTPUT=$(npx @openzeppelin/upgrades-core@"$OZ_UPGRADES_CORE_VERSION" validate "$CURRENT_BUILD" \
         --contract "$CONTRACT" \
         --reference "$QUALIFIER" 2>&1); then
       echo "$OUTPUT"

--- a/tests/test-prepare-env.sh
+++ b/tests/test-prepare-env.sh
@@ -68,5 +68,40 @@ echo "=== Testing scripts/deploy/prepare-env.sh ==="
   echo "PASS: no PRIVATE_KEY ok"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-echo "--- $((7 - FAILURES))/7 tests passed ---"
+# Test 8: Lines without = are skipped
+(
+  export PRIVATE_KEY="0xtest"
+  export DEPLOY_ENV_VARS=$'GOOD=val\nmalformed_no_equals\nALSO_GOOD=123'
+  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
+  [[ "$GOOD" == "val" ]] || { echo "FAIL: GOOD not set"; exit 1; }
+  [[ "$ALSO_GOOD" == "123" ]] || { echo "FAIL: ALSO_GOOD not set"; exit 1; }
+  echo "PASS: lines without = are skipped"
+) || { FAILURES=$((FAILURES + 1)); }
+
+# Test 9: Invalid key names are rejected
+(
+  export PRIVATE_KEY="0xtest"
+  export DEPLOY_ENV_VARS=$'GOOD_KEY=ok\nbad-key=nope\nbad key=nope'
+  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
+  [[ "$GOOD_KEY" == "ok" ]] || { echo "FAIL: GOOD_KEY not set"; exit 1; }
+  # bad-key and "bad key" should not be set as shell variables
+  [[ -z "${bad_key_marker:-}" ]] || { echo "FAIL: bad-key should not be exported"; exit 1; }
+  # Use declare -p to check — hyphenated names can't be valid bash variables anyway
+  # Just verify GOOD_KEY was the only new export
+  echo "PASS: invalid key names rejected"
+) || { FAILURES=$((FAILURES + 1)); }
+
+# Test 10: Valid keys with various value formats export correctly
+(
+  export PRIVATE_KEY="0xtest"
+  export DEPLOY_ENV_VARS=$'KEY_WITH_NUMS_123=abc\n_UNDERSCORE=yes\nVAL_WITH_EQUALS=a=b=c'
+  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
+  [[ "$KEY_WITH_NUMS_123" == "abc" ]] || { echo "FAIL: KEY_WITH_NUMS_123 not set"; exit 1; }
+  [[ "$_UNDERSCORE" == "yes" ]] || { echo "FAIL: _UNDERSCORE not set"; exit 1; }
+  [[ "$VAL_WITH_EQUALS" == "a=b=c" ]] || { echo "FAIL: VAL_WITH_EQUALS should preserve = in value, got $VAL_WITH_EQUALS"; exit 1; }
+  echo "PASS: valid keys with various values export correctly"
+) || { FAILURES=$((FAILURES + 1)); }
+
+TOTAL=10
+echo "--- $((TOTAL - FAILURES))/$TOTAL tests passed ---"
 exit $FAILURES

--- a/tests/test-prepare-env.sh
+++ b/tests/test-prepare-env.sh
@@ -68,27 +68,26 @@ echo "=== Testing scripts/deploy/prepare-env.sh ==="
   echo "PASS: no PRIVATE_KEY ok"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-# Test 8: Lines without = are skipped
+# Test 8: Lines without = cause failure
 (
   export PRIVATE_KEY="0xtest"
   export DEPLOY_ENV_VARS=$'GOOD=val\nmalformed_no_equals\nALSO_GOOD=123'
-  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
-  [[ "$GOOD" == "val" ]] || { echo "FAIL: GOOD not set"; exit 1; }
-  [[ "$ALSO_GOOD" == "123" ]] || { echo "FAIL: ALSO_GOOD not set"; exit 1; }
-  echo "PASS: lines without = are skipped"
+  if source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh" 2>/dev/null; then
+    echo "FAIL: should have failed on malformed line"
+    exit 1
+  fi
+  echo "PASS: lines without = cause failure"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-# Test 9: Invalid key names are rejected
+# Test 9: Invalid key names cause failure
 (
   export PRIVATE_KEY="0xtest"
-  export DEPLOY_ENV_VARS=$'GOOD_KEY=ok\nbad-key=nope\nbad key=nope'
-  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
-  [[ "$GOOD_KEY" == "ok" ]] || { echo "FAIL: GOOD_KEY not set"; exit 1; }
-  # bad-key and "bad key" should not be set as shell variables
-  [[ -z "${bad_key_marker:-}" ]] || { echo "FAIL: bad-key should not be exported"; exit 1; }
-  # Use declare -p to check — hyphenated names can't be valid bash variables anyway
-  # Just verify GOOD_KEY was the only new export
-  echo "PASS: invalid key names rejected"
+  export DEPLOY_ENV_VARS=$'GOOD_KEY=ok\nbad-key=nope'
+  if source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh" 2>/dev/null; then
+    echo "FAIL: should have failed on invalid key name"
+    exit 1
+  fi
+  echo "PASS: invalid key names cause failure"
 ) || { FAILURES=$((FAILURES + 1)); }
 
 # Test 10: Valid keys with various value formats export correctly


### PR DESCRIPTION
## Summary

Addresses review comments from PR #30 and findings from the security audit.

### Deploy script hardening (commit 1)
- **resolve-network.sh**: Post-fallback validation ensuring `BLOCKSCOUT_URL` is non-empty, not `"null"`, and starts with `http(s)://`
- **prepare-env.sh**: Parse and validate `KEY=VALUE` format before exporting, skip malformed lines and invalid key names
- **verify-blockscout.sh**: Add `--connect-timeout 10` and `--max-time 30` to status poll curl; normalize URL trailing slash

### Upgrade safety & workflow hardening (commit 2)
- **validate.sh**: Hard fail when base branch build/checkout fails (opt-in `ALLOW_FALLBACK=true` to downgrade to upgradeability-only)
- **validate.sh**: Pin `@openzeppelin/upgrades-core` version via `OZ_UPGRADES_CORE_VERSION` env var (default `1.44.2`)
- **validate.sh**: Fail on empty contracts array when base branch config has entries (prevents bypass)
- **_foundry-cicd.yml**: Require `upgrade-safety` job to succeed for deploy (no longer allows `skipped`)
- **_foundry-cicd.yml**: Quote `deploy-script` input to prevent flag injection
- **Both workflows**: Remove duplicate Node.js setup steps

### Address PR review comments (commit 3)
- **validate.sh**: Fail hard when base branch fetch/read fails during empty-contracts check (prevents bypass by blocking base-branch access), gated by `ALLOW_FALLBACK=true`
- **verify-blockscout.sh**: Normalize `BLOCKSCOUT_URL` once at the top and use consistently for both submission and polling (no more double-slash risk)
- **test-prepare-env.sh**: Add tests for malformed lines (no `=`), invalid key names (digits, hyphens, spaces), and values containing `=`

## Test plan
- [ ] Verify deploy fails when upgrade-safety is skipped
- [ ] Verify validate.sh fails when base branch can't be built (without ALLOW_FALLBACK)
- [ ] Verify validate.sh fails when base branch can't be fetched during empty-contracts check
- [ ] Verify validate.sh fails when contracts array is emptied but base branch has entries
- [ ] Verify pinned OZ version is used in npx calls
- [ ] Verify deploy-script input is properly quoted
- [ ] Verify prepare-env.sh tests pass (`bash tests/test-prepare-env.sh`)