### PR TITLE
fix: address PR #32 review comments

### DIFF
--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -78,10 +78,6 @@ on:
         default: 0
 
       # Upgrade Safety Options
-      run-upgrade-safety:
-        description: 'Run upgrade safety validation'
-        type: boolean
-        default: true
       upgrades-config:
         description: 'Path to upgrade safety configuration (upgrades.json)'
         type: string
@@ -391,9 +387,7 @@ jobs:
     name: Upgrade Safety
     runs-on: ubuntu-latest
     needs: [detect-changes, ci]
-    if: |
-      needs.detect-changes.outputs.should-run == 'true' &&
-      inputs.run-upgrade-safety
+    if: needs.detect-changes.outputs.should-run == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -416,7 +410,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager != 'none' && inputs.package-manager || '' }}
+          cache: ${{ inputs.package-manager }}
 
       - name: Install dependencies
         if: inputs.package-manager != 'none'
@@ -429,6 +423,12 @@ jobs:
 
       - name: Build contracts
         run: forge build --build-info --extra-output storageLayout
+
+      - name: Validate upgrades config
+        env:
+          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
+          BASE_BRANCH: ${{ inputs.main-branch }}
+        run: bash .etherform/scripts/upgrade-safety/validate-config.sh
 
       - name: Validate upgrade safety
         env:

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager != 'none' && inputs.package-manager || '' }}
+          cache: ${{ inputs.package-manager }}
 
       - name: Install dependencies
         if: inputs.package-manager != 'none'
@@ -72,6 +72,12 @@ jobs:
 
       - name: Build contracts
         run: forge build --build-info --extra-output storageLayout
+
+      - name: Validate upgrades config
+        env:
+          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
+          BASE_BRANCH: ${{ inputs.base-branch }}
+        run: bash .etherform/scripts/upgrade-safety/validate-config.sh
 
       - name: Validate upgrade safety
         env:

--- a/scripts/deploy/prepare-env.sh
+++ b/scripts/deploy/prepare-env.sh
@@ -17,7 +17,7 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
     # Expect KEY=VALUE; fail on malformed lines
     if [[ "$line" != *=* ]]; then
       echo "::error::Malformed DEPLOY_ENV_VARS line (no '='): $line"
-      return 1 2>/dev/null || exit 1
+      return 1
     fi
 
     key=${line%%=*}
@@ -26,7 +26,7 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
     # Validate KEY against a safe variable-name pattern
     if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
       echo "::error::Invalid variable name in DEPLOY_ENV_VARS: $key"
-      return 1 2>/dev/null || exit 1
+      return 1
     fi
 
     export "$key=$value"

--- a/scripts/deploy/prepare-env.sh
+++ b/scripts/deploy/prepare-env.sh
@@ -14,9 +14,10 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
   while IFS= read -r line; do
     [[ -z "$line" || "$line" == \#* ]] && continue
 
-    # Expect KEY=VALUE; skip malformed lines
+    # Expect KEY=VALUE; fail on malformed lines
     if [[ "$line" != *=* ]]; then
-      continue
+      echo "::error::Malformed DEPLOY_ENV_VARS line (no '='): $line"
+      return 1 2>/dev/null || exit 1
     fi
 
     key=${line%%=*}
@@ -24,7 +25,8 @@ if [[ -n "${DEPLOY_ENV_VARS:-}" ]]; then
 
     # Validate KEY against a safe variable-name pattern
     if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-      continue
+      echo "::error::Invalid variable name in DEPLOY_ENV_VARS: $key"
+      return 1 2>/dev/null || exit 1
     fi
 
     export "$key=$value"

--- a/scripts/upgrade-safety/validate-config.sh
+++ b/scripts/upgrade-safety/validate-config.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Validate that no contracts were removed from the upgrades config compared to the base branch.
+# Compares by .contract field only. Prevents bypassing upgrade safety by removing entries.
+#
+# Env inputs:
+#   UPGRADES_CONFIG   — required, path to upgrades.json
+#   BASE_BRANCH       — required, branch name to compare against
+
+: "${UPGRADES_CONFIG:?UPGRADES_CONFIG is required}"
+: "${BASE_BRANCH:?BASE_BRANCH is required}"
+
+if [[ ! -f "$UPGRADES_CONFIG" ]]; then
+  echo "::error::No upgrades config found at $UPGRADES_CONFIG"
+  exit 1
+fi
+
+# Fetch the base branch
+if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
+  echo "::error::Failed to fetch base branch $BASE_BRANCH — cannot validate config changes"
+  exit 1
+fi
+
+# Read base branch config
+if ! git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" > /dev/null 2>&1; then
+  echo "No $UPGRADES_CONFIG on base branch — nothing to compare against"
+  exit 0
+fi
+
+BASE_CONFIG=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}") || {
+  echo "::error::Failed to read $UPGRADES_CONFIG from base branch $BASE_BRANCH"
+  exit 1
+}
+
+CURRENT_CONTRACTS=$(jq -r '[.contracts[].contract]' "$UPGRADES_CONFIG")
+BASE_CONTRACTS=$(echo "$BASE_CONFIG" | jq -r '[.contracts[].contract]')
+
+# Find base branch contracts missing from current config
+REMOVED=$(jq -n --argjson base "$BASE_CONTRACTS" --argjson current "$CURRENT_CONTRACTS" \
+  '[$base[] | select(. as $b | $current | index($b) | not)]')
+
+REMOVED_COUNT=$(echo "$REMOVED" | jq 'length')
+
+if [[ "$REMOVED_COUNT" -gt 0 ]]; then
+  REMOVED_LIST=$(echo "$REMOVED" | jq -r '.[]')
+  echo "::error::$REMOVED_COUNT contract(s) removed from $UPGRADES_CONFIG compared to base branch ($BASE_BRANCH):"
+  echo "$REMOVED_LIST"
+  {
+    echo "## Upgrade Config Validation"
+    echo ""
+    echo "> **Error:** $REMOVED_COUNT contract(s) were removed from \`$UPGRADES_CONFIG\`:"
+    echo ""
+    echo "$REMOVED_LIST" | while read -r c; do echo "- \`$c\`"; done
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 1
+fi
+
+CURRENT_COUNT=$(echo "$CURRENT_CONTRACTS" | jq 'length')
+BASE_COUNT=$(echo "$BASE_CONTRACTS" | jq 'length')
+echo "Config validation passed: $CURRENT_COUNT contracts (base branch has $BASE_COUNT)"

--- a/scripts/upgrade-safety/validate.sh
+++ b/scripts/upgrade-safety/validate.sh
@@ -14,7 +14,6 @@ set -euo pipefail
 : "${BASE_BRANCH:?BASE_BRANCH is required}"
 : "${PACKAGE_MANAGER:?PACKAGE_MANAGER is required}"
 CURRENT_BUILD="${CURRENT_BUILD:-out/build-info}"
-ALLOW_FALLBACK="${ALLOW_FALLBACK:-false}"
 OZ_UPGRADES_CORE_VERSION="${OZ_UPGRADES_CORE_VERSION:-1.44.2}"
 
 # Check if config exists
@@ -39,64 +38,9 @@ if ! jq -e 'has("contracts")' "$UPGRADES_CONFIG" > /dev/null 2>&1; then
   exit 1
 fi
 
-# Check for empty contracts array — fail if base branch has entries (prevents bypass via emptying the config)
+# Check for empty contracts array
 CONTRACT_COUNT=$(jq '.contracts | length' "$UPGRADES_CONFIG")
 if [[ "$CONTRACT_COUNT" -eq 0 ]]; then
-  # Ensure we can access the base branch; fail hard unless ALLOW_FALLBACK=true
-  if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
-    if [[ "$ALLOW_FALLBACK" != "true" ]]; then
-      echo "::error::Failed to fetch base branch $BASE_BRANCH — cannot safely validate empty contracts configuration"
-      {
-        echo "## Upgrade Safety Validation"
-        echo ""
-        echo "> **Error:** Failed to fetch base branch \`$BASE_BRANCH\`. Cannot determine previous contracts to validate an empty \`$UPGRADES_CONFIG\`."
-      } >> "$GITHUB_STEP_SUMMARY"
-      exit 1
-    else
-      echo "::warning::Failed to fetch base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
-    fi
-  fi
-
-  BASE_CONTRACT_COUNT=0
-  if git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" > /dev/null 2>&1; then
-    if ! BASE_CONTRACT_COUNT=$(git show "origin/${BASE_BRANCH}:${UPGRADES_CONFIG}" | jq '.contracts | length' 2>/dev/null); then
-      if [[ "$ALLOW_FALLBACK" != "true" ]]; then
-        echo "::error::Failed to parse contracts from $UPGRADES_CONFIG on base branch $BASE_BRANCH"
-        {
-          echo "## Upgrade Safety Validation"
-          echo ""
-          echo "> **Error:** Could not parse contracts from \`$UPGRADES_CONFIG\` on base branch \`$BASE_BRANCH\`. Cannot safely validate an empty config."
-        } >> "$GITHUB_STEP_SUMMARY"
-        exit 1
-      else
-        echo "::warning::Failed to parse contracts from $UPGRADES_CONFIG on base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
-        BASE_CONTRACT_COUNT=0
-      fi
-    fi
-  else
-    if [[ "$ALLOW_FALLBACK" != "true" ]]; then
-      echo "::error::Unable to read $UPGRADES_CONFIG from base branch $BASE_BRANCH — cannot safely validate empty contracts configuration"
-      {
-        echo "## Upgrade Safety Validation"
-        echo ""
-        echo "> **Error:** Could not read \`$UPGRADES_CONFIG\` from base branch \`$BASE_BRANCH\`. Cannot determine previous contracts to validate an empty config."
-      } >> "$GITHUB_STEP_SUMMARY"
-      exit 1
-    else
-      echo "::warning::Unable to read $UPGRADES_CONFIG from base branch $BASE_BRANCH — proceeding with fallback because ALLOW_FALLBACK=true"
-    fi
-  fi
-
-  if [[ "$BASE_CONTRACT_COUNT" -gt 0 ]]; then
-    echo "::error::$UPGRADES_CONFIG has 0 contracts but base branch ($BASE_BRANCH) has $BASE_CONTRACT_COUNT — refusing to skip validation"
-    {
-      echo "## Upgrade Safety Validation"
-      echo ""
-      echo "> **Error:** \`$UPGRADES_CONFIG\` has no contracts, but the base branch has $BASE_CONTRACT_COUNT. This looks like an attempt to bypass validation."
-    } >> "$GITHUB_STEP_SUMMARY"
-    exit 1
-  fi
-
   echo "::warning::No contracts defined in $UPGRADES_CONFIG — skipping upgrade safety validation"
   {
     echo "## Upgrade Safety Validation"
@@ -121,7 +65,10 @@ BASE_BUILD=""
 BASE_DIR=""
 if [[ "$NEEDS_BASE" == "true" ]]; then
   echo "Building base branch ($BASE_BRANCH) for comparison..."
-  git fetch origin "$BASE_BRANCH" 2>/dev/null || true
+  if ! git fetch origin "$BASE_BRANCH" 2>/dev/null; then
+    echo "::error::Failed to fetch base branch $BASE_BRANCH — required for contracts without explicit reference"
+    exit 1
+  fi
   BASE_DIR=$(mktemp -d)
 
   if git worktree add --detach "$BASE_DIR" "origin/$BASE_BRANCH" 2>/dev/null; then
@@ -141,20 +88,12 @@ if [[ "$NEEDS_BASE" == "true" ]]; then
       BASE_BUILD="${BASE_DIR}/out/base-build-info"
       echo "Base branch built successfully"
     else
-      if [[ "$ALLOW_FALLBACK" == "true" ]]; then
-        echo "::warning::Failed to build base branch — contracts without explicit reference will be validated for upgradeability only (ALLOW_FALLBACK=true)"
-      else
-        echo "::error::Failed to build base branch. Set ALLOW_FALLBACK=true to downgrade to upgradeability-only validation."
-        exit 1
-      fi
-    fi
-  else
-    if [[ "$ALLOW_FALLBACK" == "true" ]]; then
-      echo "::warning::Could not checkout base branch '$BASE_BRANCH' — contracts without explicit reference will be validated for upgradeability only (ALLOW_FALLBACK=true)"
-    else
-      echo "::error::Could not checkout base branch '$BASE_BRANCH'. Set ALLOW_FALLBACK=true to downgrade to upgradeability-only validation."
+      echo "::error::Failed to build base branch — required for contracts without explicit reference"
       exit 1
     fi
+  else
+    echo "::error::Could not checkout base branch '$BASE_BRANCH' — required for contracts without explicit reference"
+    exit 1
   fi
 fi
 

--- a/tests/test-prepare-env.sh
+++ b/tests/test-prepare-env.sh
@@ -68,27 +68,26 @@ echo "=== Testing scripts/deploy/prepare-env.sh ==="
   echo "PASS: no PRIVATE_KEY ok"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-# Test 8: Lines without = are skipped
+# Test 8: Lines without = cause failure
 (
   export PRIVATE_KEY="0xtest"
   export DEPLOY_ENV_VARS=$'GOOD=val\nmalformed_no_equals\nALSO_GOOD=123'
-  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
-  [[ "$GOOD" == "val" ]] || { echo "FAIL: GOOD not set"; exit 1; }
-  [[ "$ALSO_GOOD" == "123" ]] || { echo "FAIL: ALSO_GOOD not set"; exit 1; }
-  echo "PASS: lines without = are skipped"
+  if source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh" 2>/dev/null; then
+    echo "FAIL: should have failed on malformed line"
+    exit 1
+  fi
+  echo "PASS: lines without = cause failure"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-# Test 9: Invalid key names are rejected
+# Test 9: Invalid key names cause failure
 (
   export PRIVATE_KEY="0xtest"
-  export DEPLOY_ENV_VARS=$'GOOD_KEY=ok\nbad-key=nope\nbad key=nope'
-  source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh"
-  [[ "$GOOD_KEY" == "ok" ]] || { echo "FAIL: GOOD_KEY not set"; exit 1; }
-  # bad-key and "bad key" should not be set as shell variables
-  [[ -z "${bad_key_marker:-}" ]] || { echo "FAIL: bad-key should not be exported"; exit 1; }
-  # Use declare -p to check — hyphenated names can't be valid bash variables anyway
-  # Just verify GOOD_KEY was the only new export
-  echo "PASS: invalid key names rejected"
+  export DEPLOY_ENV_VARS=$'GOOD_KEY=ok\nbad-key=nope'
+  if source "$SCRIPT_DIR/scripts/deploy/prepare-env.sh" 2>/dev/null; then
+    echo "FAIL: should have failed on invalid key name"
+    exit 1
+  fi
+  echo "PASS: invalid key names cause failure"
 ) || { FAILURES=$((FAILURES + 1)); }
 
 # Test 10: Valid keys with various value formats export correctly


### PR DESCRIPTION
## Summary

Addresses review comments from @rubydusa on PR #32.

- **Remove `run-upgrade-safety` input** — upgrade safety always runs; removes the issue where disabling it implicitly blocked testnet deployment
- **Simplify Node.js cache setup** — `cache: ${{ inputs.package-manager }}` instead of ternary expression; `setup-node` ignores invalid cache values
- **`prepare-env.sh` fails on malformed lines** — lines without `=` or with invalid key names now error instead of being silently skipped
- **Extract config validation to `validate-config.sh`** — checks that no `.contract` entries were removed compared to the base branch (subset check by contract name, not just count)
- **Simplify `validate.sh`** — empty contracts array is a simple skip; complex base-branch comparison logic moved to the dedicated config validation script; removed `ALLOW_FALLBACK`
- **Hard fail on base branch errors** — when contracts without explicit references exist, fetch/checkout/build failures are errors, not warnings

## Test plan
- [x] `shellcheck` passes on all scripts
- [x] All unit tests pass (`bash tests/test-*.sh`)
- [ ] Verify upgrade-safety runs unconditionally (no `run-upgrade-safety` toggle)
- [ ] Verify `validate-config.sh` catches removed contracts
- [ ] Verify `prepare-env.sh` fails on malformed `DEPLOY_ENV_VARS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)