### PR TITLE
fix: add missing package-manager guard to upgrade-safety node setup

### DIFF
--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -407,6 +407,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Setup Node.js
+        if: inputs.package-manager != 'none'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}


### PR DESCRIPTION
## Summary
- The `upgrade-safety` job unconditionally passes `inputs.package-manager` as the `cache` value to `actions/setup-node@v4`
- When `package-manager` is `none` (the default), this results in `cache: none` which `setup-node` does not support, causing the job to fail with: `Caching for 'none' is not supported`
- All other jobs already guard the `Setup Node.js` step with `if: inputs.package-manager != 'none'` — this PR adds the same guard to the `upgrade-safety` job

## Test plan
- [x] Verified all other jobs have this guard
- [ ] CI should pass on a consuming repo that uses `package-manager: none` (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)