### PR TITLE
ci(deploy): scope testnet deploy to a GitHub Environment

### DIFF
--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -37,6 +37,10 @@ on:
         description: 'Git ref for etherform scripts checkout (default: main)'
         type: string
         default: 'main'
+      environment:
+        description: 'GitHub Environment to scope the deploy to (e.g. for required reviewers + scoped secrets). Empty disables the gate.'
+        type: string
+        default: 'testnet'
     secrets:
       PRIVATE_KEY:
         required: true
@@ -50,6 +54,7 @@ jobs:
   deploy-testnet:
     name: Deploy to Testnet
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     outputs:
       network_name: ${{ steps.network.outputs.network_name }}
       blockscout_url: ${{ steps.network.outputs.blockscout_url }}

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -108,6 +108,10 @@ on:
         description: 'Verify deployed contracts on Blockscout'
         type: boolean
         default: true
+      deploy-environment:
+        description: 'GitHub Environment to scope the testnet deploy to (e.g. for required reviewers + scoped secrets). Empty disables the gate.'
+        type: string
+        default: 'testnet'
       # Halmos Options
       run-halmos:
         description: 'Run Halmos symbolic execution'
@@ -449,6 +453,7 @@ jobs:
       needs.upgrade-safety.result == 'success' &&
       inputs.deploy-on-pr &&
       github.event_name == 'pull_request'
+    environment: ${{ inputs.deploy-environment }}
     outputs:
       blockscout_url: ${{ steps.network.outputs.blockscout_url }}
       broadcast_file: ${{ steps.parse.outputs.broadcast_file }}

--- a/README.md
+++ b/README.md
@@ -184,6 +184,14 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | `RPC_URL` | All workflows | Network RPC endpoint (also used for fork-based tests) |
 | `DEPLOY_ENV_VARS` | Deploy workflows | Optional; newline-separated `KEY=VALUE` pairs exported as environment variables before running the deploy script |
 
+### Protecting deploys with a GitHub Environment
+
+The deploy job in `_deploy-testnet.yml` (and the `deploy-testnet` job in `_foundry-cicd.yml`) is scoped to a GitHub Environment via the `environment` / `deploy-environment` input (default: `testnet`).
+
+In the consumer repo, create an Environment matching that name and configure protection rules — typically **required reviewers** and a **deployment branch policy** restricted to `main`. Store `PRIVATE_KEY` (and any deploy-only secrets) on the Environment rather than the repo, so they're only available after a maintainer approves the run.
+
+To opt out (e.g., for an internal sandbox), pass an empty string: `environment: ''`.
+
 ## Workflow Inputs
 
 ### `_ci.yml`
@@ -232,6 +240,7 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | `verify-contracts` | boolean | `true` | Verify on Blockscout |
 | `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
 | `node-version` | string | `'20'` | Node.js version for package installation |
+| `environment` | string | `'testnet'` | GitHub Environment to scope the deploy to. Empty disables the gate. |
 | `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
 
 ### `_foundry-cicd.yml`
@@ -244,6 +253,7 @@ The all-in-one workflow accepts all inputs from the above workflows plus:
 | `contract-paths` | string | `src/**`, `script/**`, etc. | Paths to watch for changes |
 | `main-branch` | string | `'main'` | Base branch for upgrade safety comparison |
 | `deploy-on-pr` | boolean | `false` | Deploy to testnet on PR |
+| `deploy-environment` | string | `'testnet'` | GitHub Environment to scope the deploy to. Empty disables the gate. |
 
 All workflows also accept `etherform-ref` (default: `'main'`) to control which etherform branch the scripts are checked out from. Override this when testing against an unreleased etherform branch.
 


### PR DESCRIPTION
Closes #41.

## Summary

- Add `environment` input to `_deploy-testnet.yml` (default `testnet`).
- Add `deploy-environment` input to `_foundry-cicd.yml` (default `testnet`), forwarded to the orchestrator's `deploy-testnet` job.
- Deploy job declares `environment: ${{ inputs.* }}` so consumer repos can require reviewers and scope `PRIVATE_KEY` to the Environment.
- README documents how to set up the Environment in the consumer repo.

## Why

Closes the gap between `docs/specs/...` (which calls for "deploy on **approved** PR to main") and the implementation. Today any PR with `deploy-on-pr: true` deploys without approval. With this change, the consumer repo's Environment protection rules (required reviewers, branch policy) are the gate.

## Behavior change

- **Default consumers** must create a `testnet` Environment in their repo, or runs will sit waiting (or fail with "no environment found", depending on the GH config). This is intended — it's the point of the gate.
- Consumers who want the previous unscoped behavior can pass `environment: ''` / `deploy-environment: ''`.

## Test plan

- [x] All unit tests pass.
- [x] YAML validates.
- [ ] CI green.
- [ ] Smoke test in a consumer repo with a `testnet` Environment configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)