### PR TITLE
ci: add foundry-version input for reproducible builds

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -61,6 +61,10 @@ on:
         description: 'Git ref for etherform scripts checkout (default: main)'
         type: string
         default: 'main'
+      foundry-version:
+        description: 'Foundry release channel or tag (e.g. stable, nightly, v1.0.0)'
+        type: string
+        default: 'stable'
     secrets:
       RPC_URL:
         description: 'RPC endpoint for fork-based tests'
@@ -78,6 +82,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -122,6 +128,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -169,6 +177,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -233,6 +243,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -37,6 +37,10 @@ on:
         description: 'Git ref for etherform scripts checkout (default: main)'
         type: string
         default: 'main'
+      foundry-version:
+        description: 'Foundry release channel or tag (e.g. stable, nightly, v1.0.0)'
+        type: string
+        default: 'stable'
     secrets:
       PRIVATE_KEY:
         required: true
@@ -70,6 +74,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -161,6 +167,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Download broadcast artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -119,6 +119,10 @@ on:
         description: 'Git ref for etherform scripts checkout (default: main)'
         type: string
         default: 'main'
+      foundry-version:
+        description: 'Foundry release channel or tag (e.g. stable, nightly, v1.0.0)'
+        type: string
+        default: 'stable'
 
     secrets:
       PRIVATE_KEY:
@@ -187,6 +191,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -234,6 +240,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -285,6 +293,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -352,6 +362,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -405,6 +417,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -468,6 +482,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         if: inputs.package-manager != 'none'
@@ -549,6 +565,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Download broadcast artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -33,6 +33,10 @@ on:
         description: 'Git ref for etherform scripts checkout (default: main)'
         type: string
         default: 'main'
+      foundry-version:
+        description: 'Foundry release channel or tag (e.g. stable, nightly, v1.0.0)'
+        type: string
+        default: 'stable'
 jobs:
   upgrade-safety:
     name: Validate Upgrade Safety
@@ -54,6 +58,8 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: ${{ inputs.foundry-version }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | `coverage-min-threshold` | number | `0` | Minimum coverage % to pass (0 = disabled) |
 | `run-halmos` | boolean | `false` | Run Halmos symbolic execution |
 | `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
+| `foundry-version` | string | `'stable'` | Foundry release channel or tag (e.g. `stable`, `nightly`, `v1.0.0`) |
 
 | Secret | Required | Description |
 |--------|----------|-------------|
@@ -220,6 +221,7 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | `upgrades-config` | string | `'.github/upgrades.json'` | Path to upgrade safety config |
 | `base-branch` | string | `'main'` | Base branch for upgrade safety comparison |
 | `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
+| `foundry-version` | string | `'stable'` | Foundry release channel or tag |
 
 ### `_deploy-testnet.yml`
 
@@ -233,6 +235,7 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
 | `node-version` | string | `'20'` | Node.js version for package installation |
 | `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
+| `foundry-version` | string | `'stable'` | Foundry release channel or tag |
 
 ### `_foundry-cicd.yml`
 
@@ -246,6 +249,8 @@ The all-in-one workflow accepts all inputs from the above workflows plus:
 | `deploy-on-pr` | boolean | `false` | Deploy to testnet on PR |
 
 All workflows also accept `etherform-ref` (default: `'main'`) to control which etherform branch the scripts are checked out from. Override this when testing against an unreleased etherform branch.
+
+All workflows also accept `foundry-version` (default: `'stable'`) which is forwarded to `foundry-rs/foundry-toolchain`. Default behavior tracks the latest stable Foundry release; pass a specific tag like `'v1.0.0'` for fully reproducible builds.
 
 ## Scripts
 


### PR DESCRIPTION
Closes #43.

## Summary

- Add a `foundry-version` input to each of the four reusable workflows.
- Default `'stable'` — foundry-toolchain's stable channel, which tracks the latest stable Foundry release.
- Forward to `foundry-rs/foundry-toolchain`'s `version` input.
- README updated.

## Why

Today every workflow runs `foundry-rs/foundry-toolchain@v1` with no `version`, which installs nightly. Yesterday's green PR can fail today on a nightly drift, and consumers have no way to opt out.

## Behavior change

- **Default consumers** move from nightly → stable. This is a real version bump and may surface latent test failures that depended on nightly-only flags. Worth flagging in release notes.
- Consumers who want nightly back can pass `foundry-version: 'nightly'`.

## Out of scope (follow-ups)

- Halmos version pinning (\`pip install halmos\` is unversioned).
- Exposing the OZ upgrades-core CLI version (currently hard-coded as \`OZ_UPGRADES_CORE_VERSION\` in \`scripts/upgrade-safety/validate.sh\`).

## Test plan

- [x] All 25 unit tests pass.
- [x] YAML validates.
- [ ] CI green.
- [ ] Smoke test against a consumer repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)