### PR TITLE
Overhaul workflows: dedup, supply-chain hardening, bug fixes, e2e tests

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint's context schema lags behind GitHub: job.workflow_sha /
+# job.workflow_ref (the SHA/ref of the reusable workflow file that defines the
+# current job) are documented at
+# https://docs.github.com/en/actions/reference/workflows-and-actions/contexts
+# but not yet in actionlint's `job` context type.
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      - 'property "workflow_sha" is not defined in object type'
+      - 'property "workflow_ref" is not defined in object type'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,76 @@
+name: Setup Foundry toolchain
+description: >-
+  Shared setup for etherform jobs: installs Foundry, optionally sets up Node.js
+  and installs package-manager dependencies, and restores the Foundry compile cache.
+  The consumer repository must already be checked out.
+
+inputs:
+  foundry-version:
+    description: Foundry version to install (stable, nightly, or a specific version)
+    required: false
+    default: stable
+  package-manager:
+    description: Package manager for Node.js dependencies (none, npm, yarn, pnpm)
+    required: false
+    default: none
+  node-version:
+    description: Node.js version for package installation
+    required: false
+    default: '22'
+  working-directory:
+    description: Directory containing the Foundry project
+    required: false
+    default: '.'
+  cache:
+    description: Restore/save the Foundry compile cache between runs
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - name: Install Foundry
+      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+      with:
+        version: ${{ inputs.foundry-version }}
+
+    - name: Setup Node.js
+      if: inputs.package-manager != 'none'
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: ${{ inputs.package-manager }}
+        cache-dependency-path: |
+          ${{ inputs.working-directory }}/package-lock.json
+          ${{ inputs.working-directory }}/yarn.lock
+          ${{ inputs.working-directory }}/pnpm-lock.yaml
+
+    - name: Install dependencies
+      if: inputs.package-manager != 'none'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        PACKAGE_MANAGER: ${{ inputs.package-manager }}
+      run: |
+        case "$PACKAGE_MANAGER" in
+          npm)  npm ci ;;
+          yarn) yarn --frozen-lockfile ;;
+          pnpm) corepack enable && pnpm install --frozen-lockfile ;;
+          *)
+            echo "::error::Unsupported package-manager '$PACKAGE_MANAGER' (expected none, npm, yarn, pnpm)"
+            exit 1
+            ;;
+        esac
+
+    - name: Restore Foundry compile cache
+      if: inputs.cache == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ inputs.working-directory }}/cache
+        key: foundry-compile-${{ runner.os }}-${{ hashFiles(format('{0}/foundry.toml', inputs.working-directory), format('{0}/src/**/*.sol', inputs.working-directory)) }}
+        restore-keys: |
+          foundry-compile-${{ runner.os }}-
+
+    - name: Show Forge version
+      shell: bash
+      run: forge --version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keeps the SHA-pinned actions in workflows and the composite setup action
+# fresh; Dependabot updates the pin and the trailing version comment together.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - "/"
+      - "/.github/actions/setup"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -10,7 +10,7 @@ on:
         type: boolean
         default: true
       test-verbosity:
-        description: 'Test verbosity level (v, vv, vvv, vvvv)'
+        description: 'Test verbosity level (v, vv, vvv, vvvv, vvvvv)'
         type: string
         default: 'vvv'
       package-manager:
@@ -20,7 +20,15 @@ on:
       node-version:
         description: 'Node.js version for package installation'
         type: string
-        default: '20'
+        default: '22'
+      foundry-version:
+        description: 'Foundry version to install (stable, nightly, or a specific version)'
+        type: string
+        default: 'stable'
+      working-directory:
+        description: 'Directory containing the Foundry project (for monorepos)'
+        type: string
+        default: '.'
       run-slither:
         description: 'Run Slither static analysis'
         type: boolean
@@ -57,10 +65,14 @@ on:
         description: 'Run Halmos symbolic execution'
         type: boolean
         default: false
-      etherform-ref:
-        description: 'Git ref for etherform scripts checkout (default: main)'
+      halmos-version:
+        description: 'Halmos version to install (empty = latest)'
         type: string
-        default: 'main'
+        default: ''
+      etherform-ref:
+        description: 'Git ref for etherform scripts checkout (default: the ref this workflow was called at)'
+        type: string
+        default: ''
     secrets:
       RPC_URL:
         description: 'RPC endpoint for fork-based tests'
@@ -70,33 +82,32 @@ jobs:
   check:
     name: Build & Test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          repository: BreadchainCoop/etherform
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
+          path: .etherform
+          sparse-checkout: |
+            scripts
+            .github/actions
+
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
+        with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Show Forge version
-        run: forge --version
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Check formatting
         if: inputs.check-formatting
@@ -108,43 +119,55 @@ jobs:
       - name: Run tests
         env:
           RPC_URL: ${{ secrets.RPC_URL }}
-        run: forge test -${{ inputs.test-verbosity }}
+          TEST_VERBOSITY: ${{ inputs.test-verbosity }}
+        run: |
+          case "$TEST_VERBOSITY" in
+            v|vv|vvv|vvvv|vvvvv) ;;
+            *)
+              echo "::error::Invalid test-verbosity '$TEST_VERBOSITY' (expected v, vv, vvv, vvvv, or vvvvv)"
+              exit 1
+              ;;
+          esac
+          forge test -"$TEST_VERBOSITY"
 
   slither:
     name: Slither Analysis
     runs-on: ubuntu-latest
     if: inputs.run-slither
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
+          repository: BreadchainCoop/etherform
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
+          path: .etherform
+          sparse-checkout: |
+            scripts
+            .github/actions
 
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
+        with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
+          node-version: ${{ inputs.node-version }}
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Build for Slither
         run: forge build --build-info --skip '*/test/**' '*/script/**' --force
 
       - name: Run Slither
-        uses: crytic/slither-action@v0.4.0
+        uses: crytic/slither-action@b52cc1cbfee9ca3e8722dd5224299d16c9a6b80f # v0.4.2
         with:
+          target: ${{ inputs.working-directory }}
           slither-config: ${{ inputs.slither-config }}
           fail-on: ${{ inputs.slither-fail-on }}
 
@@ -153,48 +176,40 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check]
     if: inputs.run-coverage
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
 
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
           path: .etherform
-          sparse-checkout: scripts
+          sparse-checkout: |
+            scripts
+            .github/actions
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
         with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Show Forge version
-        run: forge --version
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Run coverage
         env:
           RPC_URL: ${{ secrets.RPC_URL }}
+          COVERAGE_EXCLUDE_PATHS: ${{ inputs.coverage-exclude-paths }}
         run: |
-          if [[ -n "${{ inputs.coverage-exclude-paths }}" ]]; then
-            forge coverage --no-match-path "${{ inputs.coverage-exclude-paths }}" 2>&1 | tee coverage-raw.txt
+          if [[ -n "$COVERAGE_EXCLUDE_PATHS" ]]; then
+            forge coverage --no-match-path "$COVERAGE_EXCLUDE_PATHS" 2>&1 | tee coverage-raw.txt
           else
             forge coverage 2>&1 | tee coverage-raw.txt
           fi
@@ -203,13 +218,14 @@ jobs:
         id: summary
         env:
           COVERAGE_SOURCE_FILTER: ${{ inputs.coverage-source-filter }}
-        run: bash .etherform/scripts/coverage/extract-summary.sh
+        run: bash "$GITHUB_WORKSPACE/.etherform/scripts/coverage/extract-summary.sh"
 
       - name: Post coverage comment
         if: inputs.coverage-post-comment && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
-          path: coverage-comment.md
+          header: coverage
+          path: ${{ inputs.working-directory }}/coverage-comment.md
 
       - name: Check coverage threshold
         if: inputs.coverage-min-threshold > 0
@@ -219,44 +235,48 @@ jobs:
           STMTS_PCT: ${{ steps.summary.outputs.stmts_pct }}
           BRANCH_PCT: ${{ steps.summary.outputs.branch_pct }}
           FUNCS_PCT: ${{ steps.summary.outputs.funcs_pct }}
-        run: bash .etherform/scripts/coverage/check-threshold.sh
+        run: bash "$GITHUB_WORKSPACE/.etherform/scripts/coverage/check-threshold.sh"
 
   halmos:
     name: Symbolic Execution
     runs-on: ubuntu-latest
     if: inputs.run-halmos
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
+          repository: BreadchainCoop/etherform
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
+          path: .etherform
+          sparse-checkout: |
+            scripts
+            .github/actions
 
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
+        with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
+          node-version: ${{ inputs.node-version }}
+          working-directory: ${{ inputs.working-directory }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Install Halmos
-        run: pip install halmos
+        env:
+          HALMOS_VERSION: ${{ inputs.halmos-version }}
+        run: pip install "halmos${HALMOS_VERSION:+==$HALMOS_VERSION}"
 
       - name: Run Halmos
         env:

--- a/.github/workflows/_deploy-testnet.yml
+++ b/.github/workflows/_deploy-testnet.yml
@@ -1,6 +1,11 @@
-# Reusable testnet deployment workflow
+# Reusable deployment workflow (testnet or mainnet)
 # Usage: jobs.<job>.uses: BreadchainCoop/etherform/.github/workflows/_deploy-testnet.yml@main
-name: Deploy Testnet (Reusable)
+#
+# The target network is determined by the RPC_URL secret; the chain ID from the
+# broadcast artifact is matched against the network config to resolve the
+# explorer URL and network name. Set the `environment` input to run the deploy
+# under a protected GitHub Environment (e.g. for mainnet deploys on merge).
+name: Deploy (Reusable)
 
 on:
   workflow_call:
@@ -13,10 +18,6 @@ on:
         description: 'Path to network configuration JSON'
         type: string
         default: '.github/deploy-networks.json'
-      network-index:
-        description: 'Index in testnets array to deploy to'
-        type: number
-        default: 0
       indexing-wait:
         description: 'Seconds to wait for indexer before verification'
         type: number
@@ -25,6 +26,10 @@ on:
         description: 'Verify deployed contracts on Blockscout'
         type: boolean
         default: true
+      environment:
+        description: 'GitHub Environment to deploy under (empty = none); use a protected environment for mainnet'
+        type: string
+        default: ''
       package-manager:
         description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
         type: string
@@ -32,11 +37,15 @@ on:
       node-version:
         description: 'Node.js version for package installation'
         type: string
-        default: '20'
-      etherform-ref:
-        description: 'Git ref for etherform scripts checkout (default: main)'
+        default: '22'
+      foundry-version:
+        description: 'Foundry version to install (stable, nightly, or a specific version)'
         type: string
-        default: 'main'
+        default: 'stable'
+      etherform-ref:
+        description: 'Git ref for etherform scripts checkout (default: the ref this workflow was called at)'
+        type: string
+        default: ''
     secrets:
       PRIVATE_KEY:
         required: true
@@ -47,9 +56,14 @@ on:
         required: false
 
 jobs:
-  deploy-testnet:
-    name: Deploy to Testnet
+  deploy:
+    name: Deploy Contracts
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    # Serialize deploys per ref; never cancel an in-flight deploy
+    concurrency:
+      group: etherform-deploy-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: read
       pull-requests: write
@@ -59,80 +73,74 @@ jobs:
       broadcast_file: ${{ steps.parse.outputs.broadcast_file }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
 
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
           path: .etherform
-          sparse-checkout: scripts
+          sparse-checkout: |
+            scripts
+            .github/actions
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
         with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Read network config
-        id: network
-        run: |
-          BLOCKSCOUT_URL=$(jq -r '.testnets[${{ inputs.network-index }}].blockscout_url' ${{ inputs.network-config-path }})
-          NETWORK_NAME=$(jq -r '.testnets[${{ inputs.network-index }}].name' ${{ inputs.network-config-path }})
-          echo "blockscout_url=$BLOCKSCOUT_URL" >> $GITHUB_OUTPUT
-          echo "network_name=$NETWORK_NAME" >> $GITHUB_OUTPUT
 
       - name: Deploy contracts
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           RPC_URL: ${{ secrets.RPC_URL }}
           DEPLOY_ENV_VARS: ${{ secrets.DEPLOY_ENV_VARS }}
+          DEPLOY_SCRIPT: ${{ inputs.deploy-script }}
         run: |
           source .etherform/scripts/deploy/prepare-env.sh
-          forge script ${{ inputs.deploy-script }} \
+          forge script "$DEPLOY_SCRIPT" \
             --rpc-url "$RPC_URL" \
+            --private-key "$PRIVATE_KEY" \
             --broadcast \
             --slow \
             -vvvv
 
       - name: Wait for indexing
-        run: sleep ${{ inputs.indexing-wait }}
+        env:
+          INDEXING_WAIT: ${{ inputs.indexing-wait }}
+        run: sleep "$INDEXING_WAIT"
 
       - name: Parse deployment addresses
         id: parse
+        env:
+          DEPLOY_SCRIPT: ${{ inputs.deploy-script }}
         run: bash .etherform/scripts/deploy/parse-broadcast.sh
 
-      - name: Save deployment artifacts
-        run: |
-          mkdir -p deployments/${{ steps.network.outputs.network_name }}
-          BROADCAST_FILE="${{ steps.parse.outputs.broadcast_file }}"
-          jq '{contracts: [.transactions[] | select(.transactionType == "CREATE") | {sourcePathAndName: "src/\(.contractName).sol:\(.contractName)", address: .contractAddress}]}' "$BROADCAST_FILE" \
-            > deployments/${{ steps.network.outputs.network_name }}/deployment.json
+      - name: Resolve network from chain ID
+        id: network
+        env:
+          CHAIN_ID: ${{ steps.parse.outputs.chain_id }}
+          NETWORK_CONFIG: ${{ inputs.network-config-path }}
+        run: bash .etherform/scripts/deploy/resolve-network.sh
+
+      - name: Write deployment artifact
+        env:
+          BROADCAST_FILE: ${{ steps.parse.outputs.broadcast_file }}
+          NETWORK_NAME: ${{ steps.network.outputs.network_name }}
+        run: bash .etherform/scripts/deploy/write-deployment-json.sh
 
       - name: Upload deployment artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deployment-${{ steps.network.outputs.network_name }}
           path: deployments/
 
       - name: Upload broadcast artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: broadcast
           path: broadcast/
@@ -140,7 +148,7 @@ jobs:
       - name: Create deployment summary
         env:
           BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
-          SUMMARY_TITLE: Testnet Deployment Summary
+          SUMMARY_TITLE: Deployment Summary
         run: bash .etherform/scripts/deploy/deployment-summary.sh
 
       - name: Write deployment comment
@@ -152,7 +160,7 @@ jobs:
 
       - name: Post deployment comment
         if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: testnet-deployment-${{ steps.network.outputs.network_name }}
           path: deployment-comment.md
@@ -160,34 +168,40 @@ jobs:
   verify-contracts:
     name: Verify Contracts
     runs-on: ubuntu-latest
-    needs: [deploy-testnet]
+    needs: [deploy]
     if: inputs.verify-contracts
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
 
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
           path: .etherform
-          sparse-checkout: scripts
+          sparse-checkout: |
+            scripts
+            .github/actions
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
+        with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
+          node-version: ${{ inputs.node-version }}
 
       - name: Download broadcast artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: broadcast
           path: broadcast/
 
       - name: Verify contracts on Blockscout
         env:
-          BLOCKSCOUT_URL: ${{ needs.deploy-testnet.outputs.blockscout_url }}
+          BLOCKSCOUT_URL: ${{ needs.deploy.outputs.blockscout_url }}
           ETH_RPC_URL: ${{ secrets.RPC_URL }}
-          BROADCAST_FILE: ${{ needs.deploy-testnet.outputs.broadcast_file }}
+          BROADCAST_FILE: ${{ needs.deploy.outputs.broadcast_file }}
         run: bash .etherform/scripts/deploy/verify-blockscout.sh

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -1,5 +1,9 @@
 # All-in-one Foundry CI/CD reusable workflow
 # Usage: jobs.<job>.uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@main
+#
+# Thin orchestrator: change detection runs inline; CI, upgrade safety, and
+# deploy are delegated to the sibling reusable workflows (_ci.yml,
+# _upgrade-safety.yml, _deploy-testnet.yml) so the logic lives in one place.
 name: Foundry CI/CD
 
 on:
@@ -27,11 +31,19 @@ on:
         type: boolean
         default: true
       test-verbosity:
-        description: 'Test verbosity level (v, vv, vvv, vvvv)'
+        description: 'Test verbosity level (v, vv, vvv, vvvv, vvvvv)'
         type: string
         default: 'vvv'
+      working-directory:
+        description: 'Directory containing the Foundry project (applies to CI, coverage, Slither, Halmos; upgrade safety and deploy assume the repo root)'
+        type: string
+        default: '.'
 
-      # Node.js Dependency Options
+      # Toolchain Options
+      foundry-version:
+        description: 'Foundry version to install (stable, nightly, or a specific version)'
+        type: string
+        default: 'stable'
       package-manager:
         description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
         type: string
@@ -39,7 +51,7 @@ on:
       node-version:
         description: 'Node.js version for package installation'
         type: string
-        default: '20'
+        default: '22'
 
       # Slither Options
       run-slither:
@@ -77,15 +89,29 @@ on:
         type: number
         default: 0
 
+      # Halmos Options
+      run-halmos:
+        description: 'Run Halmos symbolic execution'
+        type: boolean
+        default: false
+      halmos-version:
+        description: 'Halmos version to install (empty = latest)'
+        type: string
+        default: ''
+
       # Upgrade Safety Options
       upgrades-config:
-        description: 'Path to upgrade safety configuration (upgrades.json)'
+        description: 'Path to upgrade safety configuration (upgrades.json); the job is skipped when the file does not exist'
         type: string
         default: '.github/upgrades.json'
-      main-branch:
+      base-branch:
         description: 'Base branch for upgrade safety comparison'
         type: string
         default: 'main'
+      oz-upgrades-core-version:
+        description: 'Version of @openzeppelin/upgrades-core used for validation'
+        type: string
+        default: '1.44.2'
 
       # Deploy Options
       deploy-on-pr:
@@ -108,17 +134,12 @@ on:
         description: 'Verify deployed contracts on Blockscout'
         type: boolean
         default: true
-      # Halmos Options
-      run-halmos:
-        description: 'Run Halmos symbolic execution'
-        type: boolean
-        default: false
 
       # Etherform Options
       etherform-ref:
-        description: 'Git ref for etherform scripts checkout (default: main)'
+        description: 'Git ref for etherform scripts checkout (default: the ref this workflow was called at)'
         type: string
-        default: 'main'
+        default: ''
 
     secrets:
       PRIVATE_KEY:
@@ -138,444 +159,128 @@ jobs:
     outputs:
       contracts-changed: ${{ steps.filter.outputs.contracts }}
       should-run: ${{ steps.decide.outputs.should-run }}
+      upgrades-config-exists: ${{ steps.upgrades.outputs.exists }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
-          fetch-depth: 0
+          persist-credentials: true
 
       - name: Build paths filter
         id: paths
+        env:
+          CONTRACT_PATHS: ${{ inputs.contract-paths }}
         run: |
           # Convert newline-separated paths to YAML list format
-          YAML_PATHS=$(echo "${{ inputs.contract-paths }}" | sed '/^$/d' | sed 's/^/    - /')
-          echo "filter<<EOF" >> $GITHUB_OUTPUT
-          echo "contracts:" >> $GITHUB_OUTPUT
-          echo "$YAML_PATHS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          YAML_PATHS=$(printf '%s\n' "$CONTRACT_PATHS" | sed '/^$/d' | sed 's/^/    - /')
+          {
+            echo "filter<<EOF"
+            echo "contracts:"
+            echo "$YAML_PATHS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check for contract changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: ${{ steps.paths.outputs.filter }}
 
       - name: Decide whether to run
         id: decide
+        env:
+          SKIP_IF_NO_CHANGES: ${{ inputs.skip-if-no-changes }}
+          CONTRACTS_CHANGED: ${{ steps.filter.outputs.contracts }}
         run: |
-          if [[ "${{ inputs.skip-if-no-changes }}" == "false" ]]; then
+          if [[ "$SKIP_IF_NO_CHANGES" == "false" ]]; then
             echo "Change detection disabled, workflow will run"
-            echo "should-run=true" >> $GITHUB_OUTPUT
-          elif [[ "${{ steps.filter.outputs.contracts }}" == "true" ]]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$CONTRACTS_CHANGED" == "true" ]]; then
             echo "Contract changes detected, workflow will run"
-            echo "should-run=true" >> $GITHUB_OUTPUT
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
           else
             echo "No contract changes detected, skipping workflow"
-            echo "should-run=false" >> $GITHUB_OUTPUT
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for upgrades config
+        id: upgrades
+        env:
+          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
+        run: |
+          if [[ -f "$UPGRADES_CONFIG" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No $UPGRADES_CONFIG found — upgrade safety will be skipped"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
   ci:
-    name: Build & Test
-    runs-on: ubuntu-latest
+    name: CI
     needs: [detect-changes]
     if: needs.detect-changes.outputs.should-run == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Show Forge version
-        run: forge --version
-
-      - name: Check formatting
-        if: inputs.check-formatting
-        run: forge fmt --check
-
-      - name: Build contracts
-        run: forge build
-
-      - name: Run tests
-        env:
-          RPC_URL: ${{ secrets.RPC_URL }}
-        run: forge test -${{ inputs.test-verbosity }}
-
-  slither:
-    name: Slither Analysis
-    runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: |
-      needs.detect-changes.outputs.should-run == 'true' &&
-      inputs.run-slither
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Build for Slither
-        run: forge build --build-info --skip '*/test/**' '*/script/**' --force
-
-      - name: Run Slither
-        uses: crytic/slither-action@v0.4.0
-        with:
-          slither-config: ${{ inputs.slither-config }}
-          fail-on: ${{ inputs.slither-fail-on }}
-
-  coverage:
-    name: Coverage Report
-    runs-on: ubuntu-latest
-    needs: [detect-changes, ci]
-    if: |
-      always() &&
-      needs.detect-changes.outputs.should-run == 'true' &&
-      needs.ci.result == 'success' &&
-      inputs.run-coverage
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
-        with:
-          repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
-          path: .etherform
-          sparse-checkout: scripts
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Show Forge version
-        run: forge --version
-
-      - name: Run coverage
-        env:
-          RPC_URL: ${{ secrets.RPC_URL }}
-        run: |
-          if [[ -n "${{ inputs.coverage-exclude-paths }}" ]]; then
-            forge coverage --no-match-path "${{ inputs.coverage-exclude-paths }}" 2>&1 | tee coverage-raw.txt
-          else
-            forge coverage 2>&1 | tee coverage-raw.txt
-          fi
-
-      - name: Extract summary table
-        id: summary
-        env:
-          COVERAGE_SOURCE_FILTER: ${{ inputs.coverage-source-filter }}
-        run: bash .etherform/scripts/coverage/extract-summary.sh
-
-      - name: Post coverage comment
-        if: inputs.coverage-post-comment && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          path: coverage-comment.md
-
-      - name: Check coverage threshold
-        if: inputs.coverage-min-threshold > 0
-        env:
-          THRESHOLD: ${{ inputs.coverage-min-threshold }}
-          LINES_PCT: ${{ steps.summary.outputs.lines_pct }}
-          STMTS_PCT: ${{ steps.summary.outputs.stmts_pct }}
-          BRANCH_PCT: ${{ steps.summary.outputs.branch_pct }}
-          FUNCS_PCT: ${{ steps.summary.outputs.funcs_pct }}
-        run: bash .etherform/scripts/coverage/check-threshold.sh
-
-  halmos:
-    name: Symbolic Execution
-    runs-on: ubuntu-latest
-    needs: [detect-changes]
-    if: |
-      needs.detect-changes.outputs.should-run == 'true' &&
-      inputs.run-halmos
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install Halmos
-        run: pip install halmos
-
-      - name: Run Halmos
-        env:
-          RPC_URL: ${{ secrets.RPC_URL }}
-        run: halmos
-
+    uses: ./.github/workflows/_ci.yml
+    with:
+      check-formatting: ${{ inputs.check-formatting }}
+      test-verbosity: ${{ inputs.test-verbosity }}
+      working-directory: ${{ inputs.working-directory }}
+      foundry-version: ${{ inputs.foundry-version }}
+      package-manager: ${{ inputs.package-manager }}
+      node-version: ${{ inputs.node-version }}
+      run-slither: ${{ inputs.run-slither }}
+      slither-fail-on: ${{ inputs.slither-fail-on }}
+      slither-config: ${{ inputs.slither-config }}
+      run-coverage: ${{ inputs.run-coverage }}
+      coverage-exclude-paths: ${{ inputs.coverage-exclude-paths }}
+      coverage-source-filter: ${{ inputs.coverage-source-filter }}
+      coverage-post-comment: ${{ inputs.coverage-post-comment }}
+      coverage-min-threshold: ${{ inputs.coverage-min-threshold }}
+      run-halmos: ${{ inputs.run-halmos }}
+      halmos-version: ${{ inputs.halmos-version }}
+      etherform-ref: ${{ inputs.etherform-ref }}
+    secrets:
+      RPC_URL: ${{ secrets.RPC_URL }}
 
   upgrade-safety:
     name: Upgrade Safety
-    runs-on: ubuntu-latest
     needs: [detect-changes, ci]
-    if: needs.detect-changes.outputs.should-run == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
-        with:
-          repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
-          path: .etherform
-          sparse-checkout: scripts
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Build contracts
-        run: forge build --build-info --extra-output storageLayout
-
-      - name: Validate upgrades config
-        env:
-          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
-          BASE_BRANCH: ${{ inputs.main-branch }}
-        run: bash .etherform/scripts/upgrade-safety/validate-config.sh
-
-      - name: Validate upgrade safety
-        env:
-          UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
-          BASE_BRANCH: ${{ inputs.main-branch }}
-          PACKAGE_MANAGER: ${{ inputs.package-manager }}
-        run: bash .etherform/scripts/upgrade-safety/validate.sh
+    if: |
+      needs.detect-changes.outputs.should-run == 'true' &&
+      needs.detect-changes.outputs.upgrades-config-exists == 'true'
+    uses: ./.github/workflows/_upgrade-safety.yml
+    with:
+      upgrades-config: ${{ inputs.upgrades-config }}
+      base-branch: ${{ inputs.base-branch }}
+      oz-upgrades-core-version: ${{ inputs.oz-upgrades-core-version }}
+      package-manager: ${{ inputs.package-manager }}
+      node-version: ${{ inputs.node-version }}
+      foundry-version: ${{ inputs.foundry-version }}
+      etherform-ref: ${{ inputs.etherform-ref }}
 
   deploy-testnet:
     name: Deploy Testnet
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     needs: [detect-changes, ci, upgrade-safety]
+    # Deploys only on same-repo pull requests: fork PRs have no secrets, and
+    # a skipped upgrade-safety job (no upgrades.json) does not block deploys.
     if: |
       always() &&
       needs.detect-changes.outputs.should-run == 'true' &&
       needs.ci.result == 'success' &&
-      needs.upgrade-safety.result == 'success' &&
+      (needs.upgrade-safety.result == 'success' || needs.upgrade-safety.result == 'skipped') &&
       inputs.deploy-on-pr &&
-      github.event_name == 'pull_request'
-    outputs:
-      blockscout_url: ${{ steps.network.outputs.blockscout_url }}
-      broadcast_file: ${{ steps.parse.outputs.broadcast_file }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
-        with:
-          repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
-          path: .etherform
-          sparse-checkout: scripts
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Setup Node.js
-        if: inputs.package-manager != 'none'
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
-
-      - name: Deploy contracts
-        env:
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-          RPC_URL: ${{ secrets.RPC_URL }}
-          DEPLOY_ENV_VARS: ${{ secrets.DEPLOY_ENV_VARS }}
-        run: |
-          source .etherform/scripts/deploy/prepare-env.sh
-          forge script "${{ inputs.deploy-script }}" \
-            --rpc-url "$RPC_URL" \
-            --private-key "$PRIVATE_KEY" \
-            --broadcast \
-            --slow \
-            -vvvv
-
-      - name: Wait for indexing
-        run: sleep ${{ inputs.indexing-wait }}
-
-      - name: Parse deployment addresses
-        id: parse
-        run: bash .etherform/scripts/deploy/parse-broadcast.sh
-
-      - name: Upload broadcast artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: broadcast
-          path: broadcast/
-
-      - name: Resolve Blockscout URL from chain ID
-        id: network
-        env:
-          CHAIN_ID: ${{ steps.parse.outputs.chain_id }}
-          NETWORK_CONFIG: ${{ inputs.network-config-path }}
-        run: bash .etherform/scripts/deploy/resolve-network.sh
-
-      - name: Create deployment summary
-        env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
-          SUMMARY_TITLE: Testnet Deployment Summary
-        run: bash .etherform/scripts/deploy/deployment-summary.sh
-
-      - name: Write deployment comment
-        if: github.event_name == 'pull_request'
-        env:
-          BLOCKSCOUT_URL: ${{ steps.network.outputs.blockscout_url }}
-          NETWORK_NAME: ${{ steps.network.outputs.network_name }}
-        run: bash .etherform/scripts/deploy/deployment-comment.sh
-
-      - name: Post deployment comment
-        if: github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: testnet-deployment-${{ steps.network.outputs.network_name }}
-          path: deployment-comment.md
-
-  verify-contracts:
-    name: Verify Contracts
-    runs-on: ubuntu-latest
-    needs: [deploy-testnet]
-    if: |
-      always() &&
-      needs.deploy-testnet.result == 'success' &&
-      inputs.verify-contracts
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
-        with:
-          repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
-          path: .etherform
-          sparse-checkout: scripts
-
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-
-      - name: Download broadcast artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: broadcast
-          path: broadcast/
-
-      - name: Verify contracts on Blockscout
-        env:
-          BLOCKSCOUT_URL: ${{ needs.deploy-testnet.outputs.blockscout_url }}
-          ETH_RPC_URL: ${{ secrets.RPC_URL }}
-          BROADCAST_FILE: ${{ needs.deploy-testnet.outputs.broadcast_file }}
-        run: bash .etherform/scripts/deploy/verify-blockscout.sh
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/_deploy-testnet.yml
+    with:
+      deploy-script: ${{ inputs.deploy-script }}
+      network-config-path: ${{ inputs.network-config-path }}
+      indexing-wait: ${{ inputs.indexing-wait }}
+      verify-contracts: ${{ inputs.verify-contracts }}
+      package-manager: ${{ inputs.package-manager }}
+      node-version: ${{ inputs.node-version }}
+      foundry-version: ${{ inputs.foundry-version }}
+      etherform-ref: ${{ inputs.etherform-ref }}
+    secrets:
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+      RPC_URL: ${{ secrets.RPC_URL }}
+      DEPLOY_ENV_VARS: ${{ secrets.DEPLOY_ENV_VARS }}

--- a/.github/workflows/_foundry-cicd.yml
+++ b/.github/workflows/_foundry-cicd.yml
@@ -108,6 +108,10 @@ on:
         description: 'Base branch for upgrade safety comparison'
         type: string
         default: 'main'
+      main-branch:
+        description: 'DEPRECATED alias for base-branch. Set base-branch instead; when set, this overrides base-branch. Kept for backward compatibility and will be removed in a future release.'
+        type: string
+        default: ''
       oz-upgrades-core-version:
         description: 'Version of @openzeppelin/upgrades-core used for validation'
         type: string
@@ -215,6 +219,10 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Warn on deprecated inputs
+        if: inputs.main-branch != ''
+        run: echo "::warning::The 'main-branch' input is deprecated; rename it to 'base-branch'. It still works for now and overrides base-branch, but will be removed in a future release."
+
   ci:
     name: CI
     needs: [detect-changes]
@@ -250,7 +258,8 @@ jobs:
     uses: ./.github/workflows/_upgrade-safety.yml
     with:
       upgrades-config: ${{ inputs.upgrades-config }}
-      base-branch: ${{ inputs.base-branch }}
+      # main-branch is a deprecated alias; when set it overrides base-branch
+      base-branch: ${{ inputs.main-branch != '' && inputs.main-branch || inputs.base-branch }}
       oz-upgrades-core-version: ${{ inputs.oz-upgrades-core-version }}
       package-manager: ${{ inputs.package-manager }}
       node-version: ${{ inputs.node-version }}

--- a/.github/workflows/_upgrade-safety.yml
+++ b/.github/workflows/_upgrade-safety.yml
@@ -21,6 +21,10 @@ on:
         description: 'Base branch to compare against when no explicit reference is provided'
         type: string
         default: 'main'
+      oz-upgrades-core-version:
+        description: 'Version of @openzeppelin/upgrades-core used for validation'
+        type: string
+        default: '1.44.2'
       package-manager:
         description: 'Package manager for Node.js dependencies (none, npm, yarn, pnpm)'
         type: string
@@ -28,47 +32,49 @@ on:
       node-version:
         description: 'Node.js version for package installation'
         type: string
-        default: '20'
-      etherform-ref:
-        description: 'Git ref for etherform scripts checkout (default: main)'
+        default: '22'
+      foundry-version:
+        description: 'Foundry version to install (stable, nightly, or a specific version)'
         type: string
-        default: 'main'
+        default: 'stable'
+      etherform-ref:
+        description: 'Git ref for etherform scripts checkout (default: the ref this workflow was called at)'
+        type: string
+        default: ''
 jobs:
   upgrade-safety:
     name: Validate Upgrade Safety
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: true
 
-      - name: Checkout etherform scripts
-        uses: actions/checkout@v4
+      - name: Checkout etherform
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           repository: BreadchainCoop/etherform
-          ref: ${{ inputs.etherform-ref }}
+          ref: ${{ inputs.etherform-ref || job.workflow_sha }}
           path: .etherform
-          sparse-checkout: scripts
+          sparse-checkout: |
+            scripts
+            .github/actions
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+      - name: Setup toolchain
+        uses: ./.etherform/.github/actions/setup
+        with:
+          foundry-version: ${{ inputs.foundry-version }}
+          package-manager: ${{ inputs.package-manager }}
+          node-version: ${{ inputs.node-version }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        if: inputs.package-manager == 'none'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          cache: ${{ inputs.package-manager }}
-
-      - name: Install dependencies
-        if: inputs.package-manager != 'none'
-        run: |
-          case "${{ inputs.package-manager }}" in
-            npm)  npm ci ;;
-            yarn) yarn --frozen-lockfile ;;
-            pnpm) corepack enable && pnpm install --frozen-lockfile ;;
-          esac
 
       - name: Build contracts
         run: forge build --build-info --extra-output storageLayout
@@ -84,4 +90,5 @@ jobs:
           UPGRADES_CONFIG: ${{ inputs.upgrades-config }}
           BASE_BRANCH: ${{ inputs.base-branch }}
           PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          OZ_UPGRADES_CORE_VERSION: ${{ inputs.oz-upgrades-core-version }}
         run: bash .etherform/scripts/upgrade-safety/validate.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,36 @@
+# End-to-end test: runs the real _foundry-cicd.yml reusable workflow against
+# the fixture Foundry project in tests/fixtures/project. This exercises change
+# detection, the nested _ci.yml call (build, test, fmt, coverage + threshold),
+# and the graceful skip of upgrade safety when no upgrades.json exists.
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  fixture-cicd:
+    name: Fixture CI/CD
+    uses: ./.github/workflows/_foundry-cicd.yml
+    with:
+      working-directory: tests/fixtures/project
+      skip-if-no-changes: false
+      check-formatting: true
+      run-coverage: true
+      coverage-min-threshold: 90
+      coverage-post-comment: false
+
+  # _deploy-testnet.yml relies on `environment: <empty string>` meaning
+  # "no environment". This job fails loudly if GitHub ever changes that.
+  empty-environment-guard:
+    name: Empty Environment Guard
+    runs-on: ubuntu-latest
+    environment: ${{ github.event_name == 'schedule' && 'never-used' || '' }}
+    steps:
+      - name: Confirm empty environment is accepted
+        run: echo "empty environment string is accepted"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,43 +3,51 @@ name: Test Scripts
 on:
   push:
     branches: [main]
-    paths: ['scripts/**', 'tests/**', '.github/workflows/test.yml']
+    paths: ['scripts/**', 'tests/**', '.github/**']
   pull_request:
-    paths: ['scripts/**', 'tests/**', '.github/workflows/test.yml']
+    paths: ['scripts/**', 'tests/**', '.github/**']
+
+permissions:
+  contents: read
 
 jobs:
+  actionlint:
+    name: Workflow Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Run actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+          ./actionlint -color
+
   shellcheck:
     name: ShellCheck Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Run ShellCheck on all scripts
+      - name: Run ShellCheck on scripts
         run: find scripts/ -name '*.sh' -exec shellcheck -s bash {} +
+
+      # Tests intentionally export vars inside subshells for isolation, which
+      # trips the info-level SC2030/SC2031 checks
+      - name: Run ShellCheck on tests
+        run: find tests/ -name '*.sh' -exec shellcheck -s bash --severity=warning {} +
 
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - name: Test prepare-env
-        run: bash tests/test-prepare-env.sh
-
-      - name: Test parse-broadcast
-        run: bash tests/test-parse-broadcast.sh
-
-      - name: Test resolve-network
-        run: bash tests/test-resolve-network.sh
-
-      - name: Test deployment-summary
-        run: bash tests/test-deployment-summary.sh
-
-      - name: Test deployment-comment
-        run: bash tests/test-deployment-comment.sh
-
-      - name: Test extract-summary
-        run: bash tests/test-extract-summary.sh
-
-      - name: Test check-threshold
-        run: bash tests/test-check-threshold.sh
+      - name: Run all unit tests
+        run: |
+          FAILED=0
+          for t in tests/test-*.sh; do
+            echo "::group::$t"
+            bash "$t" || FAILED=1
+            echo "::endgroup::"
+          done
+          exit "$FAILED"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,14 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.7
+          # From actionlint_1.7.7_checksums.txt on the GitHub release
+          ACTIONLINT_SHA256: 023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+          curl -sSfLO "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" | sha256sum -c -
+          tar xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
           ./actionlint -color
 
   shellcheck:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 
 # Worktrees
 .conductor/
+
+# Fixture project build artifacts
+tests/fixtures/project/out/
+tests/fixtures/project/cache/

--- a/README.md
+++ b/README.md
@@ -435,8 +435,11 @@ The all-in-one workflow accepts all inputs from the above workflows (except `env
 | `skip-if-no-changes` | boolean | `true` | Skip if no contract files changed |
 | `contract-paths` | string | `src/**`, `script/**`, etc. | Paths to watch for changes |
 | `deploy-on-pr` | boolean | `false` | Deploy to testnet on PR |
+| `main-branch` | string | `''` | **Deprecated** alias for `base-branch`; when set it overrides `base-branch`. Emits a warning. Prefer `base-branch`. |
 
 Internally it calls `_ci.yml`, `_upgrade-safety.yml`, and `_deploy-testnet.yml` as nested reusable workflows, so check names appear as e.g. `CI/CD / ci / Build & Test`. The upgrade-safety job runs only when the `upgrades-config` file exists; deploys run only for same-repo pull requests.
+
+> **Deprecation:** the upgrade-safety base branch input was renamed `main-branch` → `base-branch` for consistency with `_upgrade-safety.yml`. `main-branch` still works (it overrides `base-branch` and logs a deprecation warning), so existing callers are not broken; migrate when convenient.
 
 All workflows also accept `etherform-ref` to override which etherform ref the bash scripts are checked out from. By default the scripts come from the same commit as the workflow you call (`job.workflow_sha`), so this is only needed for unusual setups.
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,28 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: cicd-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cicd:
     uses: BreadchainCoop/etherform/.github/workflows/_foundry-cicd.yml@main
-    secrets: inherit
 ```
 
 That's it. Push the file and PRs will run `forge build`, `forge test`, and `forge fmt --check`. No secrets or extra config files are needed yet.
 
-`pull-requests: write` is granted up front so the coverage PR comment works once you turn coverage on; it's harmless while coverage is off. `secrets: inherit` lets etherform see any secrets you add later (e.g. `RPC_URL`, `PRIVATE_KEY`) without you having to enumerate them.
+`pull-requests: write` is granted up front so the coverage PR comment works once you turn coverage on; it's harmless while coverage is off. The `concurrency` block cancels superseded CI runs when you push to a PR in quick succession (deploys are additionally serialized inside etherform and never cancelled mid-flight).
+
+When you enable features that need secrets later, pass them explicitly:
+
+```yaml
+    secrets:
+      RPC_URL: ${{ secrets.RPC_URL }}
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+```
+
+(`secrets: inherit` also works, but enumerating keeps the workflow's access explicit.)
 
 ### Step 2 — Node-managed Solidity dependencies (e.g. OpenZeppelin)
 
@@ -87,7 +100,7 @@ extra_output = ["storageLayout"]
 }
 ```
 
-Each contract is compared against the version on `main`. `_foundry-cicd.yml` runs the check by default — no additional input needed.
+Each contract is compared against the version on `main`. `_foundry-cicd.yml` runs the check automatically whenever `.github/upgrades.json` exists — no additional input needed. Without the file, the upgrade-safety job is skipped.
 
 For the rarer "compare a V2 against a V1 kept in the same repo" case, and for guidance on intentionally removing entries, see the [Upgrade Safety](#upgrade-safety) section below.
 
@@ -124,7 +137,7 @@ Deploy every PR to a testnet so end-to-end deployment behavior is validated befo
       deploy-on-pr: true
 ```
 
-The deploy job verifies the contracts on Blockscout and posts a deployment summary in the run.
+The deploy job verifies the contracts on Blockscout, writes a `deployments/<network>/deployment.json` artifact for frontends, and posts a deployment summary in the run. Deploys only run for pull requests from the same repository (fork PRs have no access to secrets), and are serialized per branch so two pushes can't interleave deployments.
 
 ### Step 5 — Coverage threshold and static analysis (optional)
 
@@ -136,10 +149,37 @@ The deploy job verifies the contracts on Blockscout and posts a deployment summa
       run-halmos: true
 ```
 
+### Step 6 — Mainnet deploys on merge (optional)
+
+The deploy workflow is network-agnostic: the chain is whatever your `RPC_URL` points at, and the chain ID from the broadcast is matched against `deploy-networks.json` for the explorer link. For mainnet, call `_deploy-testnet.yml` directly from a workflow that triggers on merge to `main`, and put it behind a [protected GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) so the deploy waits for a required reviewer:
+
+```yaml
+# .github/workflows/deploy-mainnet.yml
+name: Deploy Mainnet
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy:
+    uses: BreadchainCoop/etherform/.github/workflows/_deploy-testnet.yml@main
+    with:
+      environment: production   # protected GitHub Environment
+    secrets:
+      PRIVATE_KEY: ${{ secrets.MAINNET_PRIVATE_KEY }}
+      RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+```
+
+Add the mainnet entry (name, `chain_id`, `blockscout_url`) to the `testnets` array in `deploy-networks.json` so the explorer link resolves.
+
 ### Common pitfalls
 
 - **One workflow file, not several.** `_foundry-cicd.yml` already covers CI, upgrade safety, and deploy. Don't also add separate `_ci.yml` or `_upgrade-safety.yml` wrappers — every PR will run everything twice.
-- **Testing changes to etherform itself.** When you point `uses:` at an etherform branch (e.g. `@my-branch`), you also need to set `etherform-ref: my-branch`. The workflow does a separate sparse checkout of etherform's bash scripts that uses `etherform-ref` (default `main`); without it, your `uses:` change has no effect on the script logic.
+- **Pin your ref.** `@main` tracks etherform's latest commit. For reproducible CI, pin `uses:` to a tag or commit SHA. The bash scripts are automatically checked out at the same commit as the workflow you call (via `job.workflow_sha`), so a single pin covers both; `etherform-ref` only needs to be set to override that (rarely needed).
 - **`403 Resource not accessible by integration`.** Permissions are granted by the calling workflow, not at the org level. Start with the `permissions:` block in step 1 and grow it if a feature you turn on later requires more.
 
 ## Usage
@@ -282,6 +322,19 @@ contract MyContract is Initializable {
 
 See the [OpenZeppelin docs](https://docs.openzeppelin.com/upgrades-plugins/writing-upgradeable) for all supported annotations.
 
+Alternatively, pass extra flags to the OZ validate CLI per contract via `options` in `upgrades.json` (useful when you can't annotate the source, e.g. vendored contracts):
+
+```json
+{
+  "contracts": [
+    {
+      "contract": "src/Token.sol:Token",
+      "options": ["--unsafeAllowRenames"]
+    }
+  ]
+}
+```
+
 ## Configuration
 
 ### Network Configuration
@@ -322,9 +375,11 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `check-formatting` | boolean | `true` | Run `forge fmt --check` |
-| `test-verbosity` | string | `'vvv'` | Test verbosity (`v`, `vv`, `vvv`, `vvvv`) |
+| `test-verbosity` | string | `'vvv'` | Test verbosity (`v`, `vv`, `vvv`, `vvvv`, `vvvvv`) |
 | `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
-| `node-version` | string | `'20'` | Node.js version for package installation |
+| `node-version` | string | `'22'` | Node.js version for package installation |
+| `foundry-version` | string | `'stable'` | Foundry version (`stable`, `nightly`, or a specific version) |
+| `working-directory` | string | `'.'` | Directory containing the Foundry project (for monorepos) |
 | `run-slither` | boolean | `false` | Run Slither static analysis |
 | `slither-fail-on` | string | `'high'` | Minimum severity to fail on (`low`, `medium`, `high`) |
 | `slither-config` | string | `'slither.config.json'` | Path to slither.config.json |
@@ -334,7 +389,8 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | `coverage-post-comment` | boolean | `true` | Post coverage summary as a sticky PR comment |
 | `coverage-min-threshold` | number | `0` | Minimum coverage % to pass (0 = disabled) |
 | `run-halmos` | boolean | `false` | Run Halmos symbolic execution |
-| `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
+| `halmos-version` | string | `''` | Halmos version to install (empty = latest) |
+| `etherform-ref` | string | `''` | Git ref for etherform scripts checkout (default: the ref this workflow was called at) |
 
 | Secret | Required | Description |
 |--------|----------|-------------|
@@ -347,45 +403,55 @@ If your Foundry project uses npm/yarn/pnpm for Solidity dependencies (e.g., Open
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
-| `node-version` | string | `'20'` | Node.js version for package installation |
+| `node-version` | string | `'22'` | Node.js version for package installation |
+| `foundry-version` | string | `'stable'` | Foundry version (`stable`, `nightly`, or a specific version) |
 | `upgrades-config` | string | `'.github/upgrades.json'` | Path to upgrade safety config |
 | `base-branch` | string | `'main'` | Base branch for upgrade safety comparison |
-| `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
+| `oz-upgrades-core-version` | string | `'1.44.2'` | Version of `@openzeppelin/upgrades-core` used for validation |
+| `etherform-ref` | string | `''` | Git ref for etherform scripts checkout (default: the ref this workflow was called at) |
 
 ### `_deploy-testnet.yml`
+
+Despite the historical name, this workflow deploys to whatever network `RPC_URL` points at (see [Step 6](#step-6--mainnet-deploys-on-merge-optional) for mainnet). The chain ID from the broadcast artifact is matched against the network config to resolve the network name and explorer URL.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `deploy-script` | string | `'script/Deploy.s.sol:Deploy'` | Deployment script |
 | `network-config-path` | string | `'.github/deploy-networks.json'` | Network config path |
-| `network-index` | number | `0` | Index in testnets array |
 | `indexing-wait` | number | `60` | Seconds to wait before verification |
 | `verify-contracts` | boolean | `true` | Verify on Blockscout |
+| `environment` | string | `''` | GitHub Environment to deploy under (empty = none); use a protected environment for mainnet |
 | `package-manager` | string | `'none'` | Package manager (`none`, `npm`, `yarn`, `pnpm`) |
-| `node-version` | string | `'20'` | Node.js version for package installation |
-| `etherform-ref` | string | `'main'` | Git ref for etherform scripts checkout |
+| `node-version` | string | `'22'` | Node.js version for package installation |
+| `foundry-version` | string | `'stable'` | Foundry version (`stable`, `nightly`, or a specific version) |
+| `etherform-ref` | string | `''` | Git ref for etherform scripts checkout (default: the ref this workflow was called at) |
 
 ### `_foundry-cicd.yml`
 
-The all-in-one workflow accepts all inputs from the above workflows plus:
+The all-in-one workflow accepts all inputs from the above workflows (except `environment`) plus:
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `skip-if-no-changes` | boolean | `true` | Skip if no contract files changed |
 | `contract-paths` | string | `src/**`, `script/**`, etc. | Paths to watch for changes |
-| `main-branch` | string | `'main'` | Base branch for upgrade safety comparison |
 | `deploy-on-pr` | boolean | `false` | Deploy to testnet on PR |
 
-All workflows also accept `etherform-ref` (default: `'main'`) to control which etherform branch the scripts are checked out from. Override this when testing against an unreleased etherform branch.
+Internally it calls `_ci.yml`, `_upgrade-safety.yml`, and `_deploy-testnet.yml` as nested reusable workflows, so check names appear as e.g. `CI/CD / ci / Build & Test`. The upgrade-safety job runs only when the `upgrades-config` file exists; deploys run only for same-repo pull requests.
+
+All workflows also accept `etherform-ref` to override which etherform ref the bash scripts are checked out from. By default the scripts come from the same commit as the workflow you call (`job.workflow_sha`), so this is only needed for unusual setups.
 
 ## Scripts
 
-Shared logic is extracted into modular bash scripts under `scripts/`. Workflows check out these scripts at runtime via `actions/checkout`. The scripts are independently testable.
+Shared logic is extracted into modular bash scripts under `scripts/`. Workflows check out these scripts (and the shared setup action) at runtime via a sparse `actions/checkout` of etherform pinned to the same commit as the workflow. The scripts are independently testable.
 
 | Directory | Scripts | Purpose |
 |-----------|---------|---------|
-| `scripts/deploy/` | `prepare-env.sh`, `parse-broadcast.sh`, `resolve-network.sh`, `deployment-summary.sh`, `verify-blockscout.sh` | Deployment helpers |
+| `scripts/deploy/` | `prepare-env.sh`, `parse-broadcast.sh`, `resolve-network.sh`, `write-deployment-json.sh`, `deployment-summary.sh`, `deployment-comment.sh`, `verify-blockscout.sh` | Deployment helpers |
 | `scripts/coverage/` | `extract-summary.sh`, `check-threshold.sh` | Coverage reporting |
-| `scripts/upgrade-safety/` | `validate.sh` | Upgrade safety validation |
+| `scripts/upgrade-safety/` | `validate-config.sh`, `validate.sh` | Upgrade safety validation |
 
-Run tests locally: `bash tests/test-*.sh`
+Run tests locally: `for t in tests/test-*.sh; do bash "$t"; done`
+
+## Repo CI
+
+Etherform tests itself: `test.yml` runs actionlint, ShellCheck, and the unit tests for every script, and `e2e.yml` runs the real `_foundry-cicd.yml` against the fixture Foundry project in `tests/fixtures/project` on every PR — exercising change detection, build/test/format, coverage extraction and thresholds, and the graceful upgrade-safety skip.

--- a/docs/specs/ci-cd-automated-deployments.md
+++ b/docs/specs/ci-cd-automated-deployments.md
@@ -1,5 +1,13 @@
 # Technical Spec — Auto CI/CD: Testnet & Mainnet Deployments With Upgrade Safety Validation (Foundry + Blockscout)
 
+> **Status: partially superseded.** This is the original design document; the
+> implementation diverged in several ways. Upgrade safety uses the OpenZeppelin
+> upgrades-core CLI comparing against the base branch (not the
+> flattening/`ValidateUpgrade.s.sol` snapshot approach described below), and the
+> entry points are reusable workflows (`_foundry-cicd.yml` etc.), not a single
+> composite action. See the [README](../../README.md) for how things actually
+> work today, including mainnet deploys via protected GitHub Environments.
+
 ## 1. Background
 
 ### Problem Statement: What hurts today?

--- a/scripts/coverage/extract-summary.sh
+++ b/scripts/coverage/extract-summary.sh
@@ -28,8 +28,14 @@ total_stmts_hit=0; total_stmts_all=0
 total_branch_hit=0; total_branch_all=0
 total_funcs_hit=0; total_funcs_all=0
 
+# Pull "hit total" out of a cell like "82.35% (14/17)". POSIX sed (no GNU
+# grep -P) so the test suite also runs on macOS.
+extract() {
+  out=$(echo "$1" | sed -n -E 's|.*\(([0-9]+)/([0-9]+)\).*|\1 \2|p')
+  echo "${out:-0 0}"
+}
+
 while IFS='|' read -r _ file lines stmts branches funcs _; do
-  extract() { echo "$1" | grep -oP '\(\K[0-9]+/[0-9]+' | tr '/' ' '; }
   read -r lh lt <<< "$(extract "$lines")"
   read -r sh st <<< "$(extract "$stmts")"
   read -r bh bt <<< "$(extract "$branches")"

--- a/scripts/deploy/parse-broadcast.sh
+++ b/scripts/deploy/parse-broadcast.sh
@@ -3,20 +3,61 @@ set -euo pipefail
 # Parse Foundry broadcast artifacts after deployment.
 # Finds run-latest.json, extracts chain ID, writes deployment-summary.txt.
 #
+# Deployments are collected from top-level CREATE and CREATE2 transactions.
+# Contracts deployed by other contracts (additionalContracts) have no name in
+# the broadcast artifact; they are listed in the log but excluded from the
+# summary since they cannot be labeled or verified.
+#
+# Env inputs:
+#   DEPLOY_SCRIPT — optional, deploy script spec (e.g. script/Deploy.s.sol:Deploy);
+#                   scopes the broadcast search to that script's directory
+#
 # Outputs (via $GITHUB_OUTPUT):
 #   broadcast_file  — path to the broadcast JSON
-#   chain_id        — chain ID extracted from directory structure
+#   chain_id        — chain ID from the artifact (directory name as fallback)
 
-BROADCAST_FILE=$(find broadcast -name "run-latest.json" -type f | head -1)
-if [[ -z "$BROADCAST_FILE" ]]; then
-  echo "No broadcast file found"
+SEARCH_DIR="broadcast"
+if [[ -n "${DEPLOY_SCRIPT:-}" ]]; then
+  # script/Deploy.s.sol:Deploy -> broadcast/Deploy.s.sol
+  SCRIPT_FILE=$(basename "${DEPLOY_SCRIPT%%:*}")
+  if [[ -d "broadcast/$SCRIPT_FILE" ]]; then
+    SEARCH_DIR="broadcast/$SCRIPT_FILE"
+  fi
+fi
+
+BROADCAST_FILES=$(find "$SEARCH_DIR" -name "run-latest.json" -type f 2>/dev/null | sort)
+if [[ -z "$BROADCAST_FILES" ]]; then
+  echo "::error::No broadcast file found under $SEARCH_DIR"
   exit 1
 fi
+
+FILE_COUNT=$(echo "$BROADCAST_FILES" | wc -l | tr -d ' ')
+if [[ "$FILE_COUNT" -gt 1 ]]; then
+  echo "::error::Found $FILE_COUNT broadcast files under $SEARCH_DIR — cannot determine which deployment to use:"
+  echo "$BROADCAST_FILES"
+  echo "Set DEPLOY_SCRIPT to scope the search, or clean up stale broadcast directories."
+  exit 1
+fi
+BROADCAST_FILE="$BROADCAST_FILES"
 echo "broadcast_file=$BROADCAST_FILE" >> "$GITHUB_OUTPUT"
 
-# Extract chain ID from path: broadcast/<script>/<chain_id>/run-latest.json
-CHAIN_ID=$(echo "$BROADCAST_FILE" | sed -E 's|.*/([0-9]+)/run-latest\.json$|\1|')
+# Prefer the chain field in the artifact; fall back to the directory name
+# (broadcast/<script>/<chain_id>/run-latest.json)
+CHAIN_ID=$(jq -r '.chain // empty' "$BROADCAST_FILE")
+if [[ -z "$CHAIN_ID" ]]; then
+  CHAIN_ID=$(echo "$BROADCAST_FILE" | sed -E 's|.*/([0-9]+)/run-latest\.json$|\1|')
+fi
 echo "chain_id=$CHAIN_ID" >> "$GITHUB_OUTPUT"
 echo "Deployed to chain ID: $CHAIN_ID"
 
-jq -r '.transactions[] | select(.transactionType == "CREATE") | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt
+# Warn about unnamed nested deployments so they are not silently dropped
+UNNAMED_COUNT=$(jq '[.transactions[].additionalContracts // [] | .[]] | length' "$BROADCAST_FILE")
+if [[ "$UNNAMED_COUNT" -gt 0 ]]; then
+  echo "::warning::$UNNAMED_COUNT contract(s) were deployed by other contracts (additionalContracts). They have no name in the broadcast artifact and are excluded from the summary and verification:"
+  jq -r '.transactions[].additionalContracts // [] | .[] | "  \(.transactionType) at \(.address)"' "$BROADCAST_FILE"
+fi
+
+jq -r '.transactions[]
+  | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
+  | select(.contractName != null)
+  | "\(.contractName): \(.contractAddress)"' "$BROADCAST_FILE" | tee deployment-summary.txt

--- a/scripts/deploy/verify-blockscout.sh
+++ b/scripts/deploy/verify-blockscout.sh
@@ -30,15 +30,24 @@ fi
 # Normalize URL once (strip trailing slash) to avoid double-slash in API calls
 BLOCKSCOUT_URL="${BLOCKSCOUT_URL%/}"
 
-# Collect all CREATE contracts
+# Collect all named CREATE/CREATE2 contracts. Nested deployments
+# (additionalContracts) have no contract name in the broadcast artifact and
+# cannot be verified by name — parse-broadcast.sh warns about them.
 CONTRACTS=()
 while read -r tx; do
   name=$(echo "$tx" | jq -r '.contractName')
   addr=$(echo "$tx" | jq -r '.contractAddress')
   CONTRACTS+=("${name}:${addr}")
-done < <(jq -c '.transactions[] | select(.transactionType == "CREATE")' "$BROADCAST_FILE")
+done < <(jq -c '.transactions[]
+  | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
+  | select(.contractName != null)' "$BROADCAST_FILE")
 
 echo "Found ${#CONTRACTS[@]} contracts to verify"
+
+if [[ ${#CONTRACTS[@]} -eq 0 ]]; then
+  echo "::warning::No named CREATE/CREATE2 deployments found in $BROADCAST_FILE — nothing to verify"
+  exit 0
+fi
 
 # Phase 1: Submit all contracts for verification (no --watch)
 for entry in "${CONTRACTS[@]}"; do

--- a/scripts/deploy/write-deployment-json.sh
+++ b/scripts/deploy/write-deployment-json.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Write the deployment artifact consumed by frontends:
+#   deployments/<network>/deployment.json
+# with schema {contracts: [{sourcePathAndName, address}]}.
+#
+# Collects top-level CREATE and CREATE2 transactions from the broadcast file.
+#
+# Env inputs:
+#   BROADCAST_FILE — required, path to run-latest.json
+#   NETWORK_NAME   — required, used as the deployments/ subdirectory
+#   SOURCE_ROOT    — optional, source directory prefix (default: src)
+
+: "${BROADCAST_FILE:?BROADCAST_FILE is required}"
+: "${NETWORK_NAME:?NETWORK_NAME is required}"
+SOURCE_ROOT="${SOURCE_ROOT:-src}"
+
+mkdir -p "deployments/$NETWORK_NAME"
+
+jq --arg root "$SOURCE_ROOT" '{
+  contracts: [
+    .transactions[]
+    | select(.transactionType == "CREATE" or .transactionType == "CREATE2")
+    | select(.contractName != null)
+    | {
+        sourcePathAndName: "\($root)/\(.contractName).sol:\(.contractName)",
+        address: .contractAddress
+      }
+  ]
+}' "$BROADCAST_FILE" > "deployments/$NETWORK_NAME/deployment.json"
+
+echo "Wrote deployments/$NETWORK_NAME/deployment.json:"
+cat "deployments/$NETWORK_NAME/deployment.json"

--- a/scripts/upgrade-safety/validate.sh
+++ b/scripts/upgrade-safety/validate.sh
@@ -58,7 +58,7 @@ fi
 OZ_DIR=$(mktemp -d)
 echo "Installing @openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}..."
 (cd "$OZ_DIR" && npm init -y > /dev/null 2>&1 \
-  && npm install --no-audit --no-fund "@openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}" > /dev/null)
+  && npm install --ignore-scripts --no-audit --no-fund "@openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}" > /dev/null)
 OZ_CLI="$OZ_DIR/node_modules/.bin/openzeppelin-upgrades-core"
 if [[ ! -x "$OZ_CLI" ]]; then
   echo "::error::Failed to install @openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}"

--- a/scripts/upgrade-safety/validate.sh
+++ b/scripts/upgrade-safety/validate.sh
@@ -4,11 +4,15 @@ set -euo pipefail
 # Contracts without an explicit reference are compared against the base branch.
 # Contracts with an explicit reference are compared within the current build.
 #
+# Each contract entry may set "options": an array of extra CLI arguments passed
+# to the OZ validate command, e.g. ["--unsafeAllow", "delegatecall"].
+#
 # Env inputs:
-#   UPGRADES_CONFIG   — required, path to upgrades.json
-#   BASE_BRANCH       — required, branch name to compare against
-#   PACKAGE_MANAGER   — required, one of: none, npm, yarn, pnpm
-#   CURRENT_BUILD     — optional, default "out/build-info"
+#   UPGRADES_CONFIG          — required, path to upgrades.json
+#   BASE_BRANCH              — required, branch name to compare against
+#   PACKAGE_MANAGER          — required, one of: none, npm, yarn, pnpm
+#   CURRENT_BUILD            — optional, default "out/build-info"
+#   OZ_UPGRADES_CORE_VERSION — optional, default 1.44.2
 
 : "${UPGRADES_CONFIG:?UPGRADES_CONFIG is required}"
 : "${BASE_BRANCH:?BASE_BRANCH is required}"
@@ -49,6 +53,25 @@ if [[ "$CONTRACT_COUNT" -eq 0 ]]; then
   } >> "$GITHUB_STEP_SUMMARY"
   exit 0
 fi
+
+# Install the OZ CLI once instead of resolving it via npx per contract
+OZ_DIR=$(mktemp -d)
+echo "Installing @openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}..."
+(cd "$OZ_DIR" && npm init -y > /dev/null 2>&1 \
+  && npm install --no-audit --no-fund "@openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}" > /dev/null)
+OZ_CLI="$OZ_DIR/node_modules/.bin/openzeppelin-upgrades-core"
+if [[ ! -x "$OZ_CLI" ]]; then
+  echo "::error::Failed to install @openzeppelin/upgrades-core@${OZ_UPGRADES_CORE_VERSION}"
+  exit 1
+fi
+
+cleanup() {
+  if [[ -n "${BASE_DIR:-}" ]]; then
+    git worktree remove "$BASE_DIR" --force 2>/dev/null || true
+  fi
+  rm -rf "$OZ_DIR"
+}
+trap cleanup EXIT
 
 # Check if any contracts need base branch comparison (no explicit reference)
 NEEDS_BASE=false
@@ -107,16 +130,35 @@ while IFS= read -r entry; do
   REF_VALUE=$(echo "$entry" | jq -c '.reference // empty')
   CONTRACT_PATH="${CONTRACT%%:*}"
 
+  # Optional extra CLI arguments for this contract (e.g. --unsafeAllow delegatecall).
+  # Values are passed as an argv array (never through a shell), the pattern
+  # check just rejects obviously malformed entries early.
+  EXTRA_ARGS=()
+  OPTIONS_OK=true
+  while IFS= read -r opt; do
+    if [[ ! "$opt" =~ ^(--)?[A-Za-z0-9][A-Za-z0-9,=_-]*$ ]]; then
+      echo "::error::Invalid option for $CONTRACT in $UPGRADES_CONFIG: $opt"
+      OPTIONS_OK=false
+      break
+    fi
+    EXTRA_ARGS+=("$opt")
+  done < <(echo "$entry" | jq -r '.options // [] | .[]')
+
   echo "::group::Validating $CONTRACT"
 
-  if [[ -z "$REF_VALUE" || "$REF_VALUE" == "null" ]]; then
+  if [[ "$OPTIONS_OK" != "true" ]]; then
+    SUMMARY="${SUMMARY}| \`${CONTRACT}\` | (invalid options) | **FAIL** |"$'\n'
+    FAILED=$((FAILED + 1))
+
+  elif [[ -z "$REF_VALUE" || "$REF_VALUE" == "null" ]]; then
     # === Base branch comparison (default) ===
     if [[ -n "$BASE_BUILD" ]] && git show "origin/${BASE_BRANCH}:${CONTRACT_PATH}" > /dev/null 2>&1; then
       # Contract exists on base branch — compare storage layouts
-      if OUTPUT=$(npx @openzeppelin/upgrades-core@"$OZ_UPGRADES_CORE_VERSION" validate "$CURRENT_BUILD" \
+      if OUTPUT=$("$OZ_CLI" validate "$CURRENT_BUILD" \
           --contract "$CONTRACT" \
           --reference "base-build-info:${CONTRACT}" \
-          --referenceBuildInfoDirs "$BASE_BUILD" 2>&1); then
+          --referenceBuildInfoDirs "$BASE_BUILD" \
+          ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1); then
         echo "$OUTPUT"
         SUMMARY="${SUMMARY}| \`${CONTRACT}\` | \`${BASE_BRANCH}\` branch | Pass |"$'\n'
         PASSED=$((PASSED + 1))
@@ -128,8 +170,9 @@ while IFS= read -r entry; do
     else
       # Contract doesn't exist on base branch or base build failed — validate upgradeability only
       echo "Contract not found on $BASE_BRANCH or base build unavailable, validating upgradeability only..."
-      if OUTPUT=$(npx @openzeppelin/upgrades-core@"$OZ_UPGRADES_CORE_VERSION" validate "$CURRENT_BUILD" \
-          --contract "$CONTRACT" 2>&1); then
+      if OUTPUT=$("$OZ_CLI" validate "$CURRENT_BUILD" \
+          --contract "$CONTRACT" \
+          ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1); then
         echo "$OUTPUT"
         SUMMARY="${SUMMARY}| \`${CONTRACT}\` | (new contract) | Pass |"$'\n'
         PASSED=$((PASSED + 1))
@@ -143,9 +186,10 @@ while IFS= read -r entry; do
   elif echo "$REF_VALUE" | jq -e 'type == "string"' > /dev/null 2>&1; then
     # === Contract qualifier reference ===
     QUALIFIER=$(echo "$entry" | jq -r '.reference')
-    if OUTPUT=$(npx @openzeppelin/upgrades-core@"$OZ_UPGRADES_CORE_VERSION" validate "$CURRENT_BUILD" \
+    if OUTPUT=$("$OZ_CLI" validate "$CURRENT_BUILD" \
         --contract "$CONTRACT" \
-        --reference "$QUALIFIER" 2>&1); then
+        --reference "$QUALIFIER" \
+        ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} 2>&1); then
       echo "$OUTPUT"
       SUMMARY="${SUMMARY}| \`${CONTRACT}\` | \`${QUALIFIER}\` | Pass |"$'\n'
       PASSED=$((PASSED + 1))
@@ -163,11 +207,6 @@ while IFS= read -r entry; do
 
   echo "::endgroup::"
 done < <(jq -c '.contracts[]' "$UPGRADES_CONFIG")
-
-# Clean up worktree
-if [[ -n "$BASE_DIR" ]]; then
-  git worktree remove "$BASE_DIR" --force 2>/dev/null || true
-fi
 
 # Write Step Summary
 {

--- a/tests/fixtures/broadcast/Deploy.s.sol/31337/run-latest.json
+++ b/tests/fixtures/broadcast/Deploy.s.sol/31337/run-latest.json
@@ -10,7 +10,19 @@
       "hash": "0xdef456",
       "transactionType": "CREATE",
       "contractName": "MyProxy",
-      "contractAddress": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+      "contractAddress": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+      "additionalContracts": [
+        {
+          "transactionType": "CREATE",
+          "address": "0x9999999999999999999999999999999999999999"
+        }
+      ]
+    },
+    {
+      "hash": "0x321cba",
+      "transactionType": "CREATE2",
+      "contractName": "MyFactory",
+      "contractAddress": "0x5555555555555555555555555555555555555555"
     },
     {
       "hash": "0x789012",
@@ -18,5 +30,6 @@
       "contractName": "MyProxy",
       "contractAddress": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
     }
-  ]
+  ],
+  "chain": 31337
 }

--- a/tests/fixtures/coverage-raw-forge17.txt
+++ b/tests/fixtures/coverage-raw-forge17.txt
@@ -1,0 +1,20 @@
+Compiler run successful!
+Analysing contracts...
+Running tests...
+
+Ran 4 tests for test/Counter.t.sol:CounterTest
+[PASS] test_Decrement() (gas: 30157)
+[PASS] test_DecrementRevertsAtZero() (gas: 7633)
+[PASS] test_Increment() (gas: 28723)
+[PASS] test_SetNumber() (gas: 29062)
+Suite result: ok. 4 passed; 0 failed; 0 skipped; finished in 283.08µs (367.87µs CPU time)
+
+Ran 1 test suite in 4.43ms (283.08µs CPU time): 4 tests passed, 0 failed, 0 skipped (4 total tests)
+
+╭-----------------+---------------+---------------+---------------+---------------╮
+| File            | % Lines       | % Statements  | % Branches    | % Funcs       |
++=================================================================================+
+| src/Counter.sol | 100.00% (7/7) | 100.00% (4/4) | 100.00% (2/2) | 100.00% (3/3) |
+|-----------------+---------------+---------------+---------------+---------------|
+| Total           | 100.00% (7/7) | 100.00% (4/4) | 100.00% (2/2) | 100.00% (3/3) |
+╰-----------------+---------------+---------------+---------------+---------------╯

--- a/tests/fixtures/project/foundry.toml
+++ b/tests/fixtures/project/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "src"
+test = "test"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.28"

--- a/tests/fixtures/project/src/Counter.sol
+++ b/tests/fixtures/project/src/Counter.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/// Minimal fixture contract used by etherform's end-to-end workflow tests.
+/// Deliberately dependency-free so the fixture needs no submodules or node_modules.
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number += 1;
+    }
+
+    function decrement() public {
+        require(number > 0, "Counter: underflow");
+        number -= 1;
+    }
+}

--- a/tests/fixtures/project/test/Counter.t.sol
+++ b/tests/fixtures/project/test/Counter.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Counter} from "../src/Counter.sol";
+
+/// Dependency-free tests (no forge-std): forge discovers any contract with
+/// test-prefixed functions, and a revert marks the test as failed.
+contract CounterTest {
+    Counter internal counter;
+
+    function setUp() public {
+        counter = new Counter();
+    }
+
+    function test_SetNumber() public {
+        counter.setNumber(42);
+        require(counter.number() == 42, "setNumber failed");
+    }
+
+    function test_Increment() public {
+        counter.increment();
+        require(counter.number() == 1, "increment failed");
+    }
+
+    function test_Decrement() public {
+        counter.setNumber(2);
+        counter.decrement();
+        require(counter.number() == 1, "decrement failed");
+    }
+
+    function test_DecrementRevertsAtZero() public {
+        try counter.decrement() {
+            revert("expected underflow revert");
+        } catch {}
+    }
+}

--- a/tests/test-extract-summary.sh
+++ b/tests/test-extract-summary.sh
@@ -56,5 +56,30 @@ echo "=== Testing scripts/coverage/extract-summary.sh ==="
   echo "PASS: generates coverage-comment.md"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-echo "--- $((2 - FAILURES))/2 tests passed ---"
+# Test 3: Parses the forge >= 1.7 table format (=== header separator,
+# |--- row separators, Total row)
+(
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
+  cd "$TMPDIR"
+
+  cp "$SCRIPT_DIR/tests/fixtures/coverage-raw-forge17.txt" coverage-raw.txt
+
+  export GITHUB_OUTPUT="$TMPDIR/github-output.txt"
+  export COVERAGE_SOURCE_FILTER=" src/"
+  touch "$GITHUB_OUTPUT"
+
+  bash "$SCRIPT_DIR/scripts/coverage/extract-summary.sh"
+
+  LINES_PCT=$(grep "lines_pct=" "$GITHUB_OUTPUT" | cut -d= -f2)
+  [[ "$LINES_PCT" == "100.00" ]] || { echo "FAIL: lines_pct=$LINES_PCT, expected 100.00"; cat "$GITHUB_OUTPUT"; exit 1; }
+  BRANCH_PCT=$(grep "branch_pct=" "$GITHUB_OUTPUT" | cut -d= -f2)
+  [[ "$BRANCH_PCT" == "100.00" ]] || { echo "FAIL: branch_pct=$BRANCH_PCT, expected 100.00"; exit 1; }
+  grep -q "Counter" coverage-comment.md || { echo "FAIL: Counter not in comment"; exit 1; }
+  grep -q "Total" coverage-comment.md && { echo "FAIL: Total row should be filtered out"; exit 1; }
+
+  echo "PASS: parses forge 1.7 table format"
+) || { FAILURES=$((FAILURES + 1)); }
+
+echo "--- $((3 - FAILURES))/3 tests passed ---"
 exit $FAILURES

--- a/tests/test-parse-broadcast.sh
+++ b/tests/test-parse-broadcast.sh
@@ -5,7 +5,7 @@ FAILURES=0
 
 echo "=== Testing scripts/deploy/parse-broadcast.sh ==="
 
-# Test 1: Parses broadcast file and extracts chain ID
+# Test 1: Parses broadcast file and extracts chain ID (from the chain field)
 (
   TMPDIR=$(mktemp -d)
   trap 'rm -rf "$TMPDIR"' EXIT
@@ -23,7 +23,8 @@ echo "=== Testing scripts/deploy/parse-broadcast.sh ==="
   echo "PASS: extracts broadcast_file and chain_id"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-# Test 2: Creates deployment-summary.txt with CREATE transactions only
+# Test 2: Summary includes CREATE and CREATE2, excludes CALL and unnamed
+# nested deployments (additionalContracts)
 (
   TMPDIR=$(mktemp -d)
   trap 'rm -rf "$TMPDIR"' EXIT
@@ -35,11 +36,13 @@ echo "=== Testing scripts/deploy/parse-broadcast.sh ==="
 
   bash "$SCRIPT_DIR/scripts/deploy/parse-broadcast.sh" > /dev/null
 
-  [[ $(wc -l < deployment-summary.txt) -eq 2 ]] || { echo "FAIL: expected 2 lines, got $(wc -l < deployment-summary.txt)"; exit 1; }
+  [[ $(wc -l < deployment-summary.txt) -eq 3 ]] || { echo "FAIL: expected 3 lines, got $(wc -l < deployment-summary.txt)"; cat deployment-summary.txt; exit 1; }
   grep -q "MyToken" deployment-summary.txt || { echo "FAIL: MyToken not found"; exit 1; }
   grep -q "MyProxy" deployment-summary.txt || { echo "FAIL: MyProxy not found"; exit 1; }
+  grep -q "MyFactory" deployment-summary.txt || { echo "FAIL: MyFactory (CREATE2) not found"; exit 1; }
+  grep -q "0x9999999999999999999999999999999999999999" deployment-summary.txt && { echo "FAIL: unnamed nested deployment should be excluded"; exit 1; }
 
-  echo "PASS: deployment-summary.txt has correct CREATE entries"
+  echo "PASS: deployment-summary.txt has CREATE and CREATE2 entries only"
 ) || { FAILURES=$((FAILURES + 1)); }
 
 # Test 3: Fails when no broadcast file exists
@@ -59,5 +62,46 @@ echo "=== Testing scripts/deploy/parse-broadcast.sh ==="
   echo "PASS: fails when no broadcast file"
 ) || { FAILURES=$((FAILURES + 1)); }
 
-echo "--- $((3 - FAILURES))/3 tests passed ---"
+# Test 4: Fails on ambiguous broadcasts (multiple run-latest.json, no scoping)
+(
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
+  cp -r "$SCRIPT_DIR/tests/fixtures/broadcast" "$TMPDIR/"
+  cd "$TMPDIR"
+  mkdir -p broadcast/Other.s.sol/1
+  cp broadcast/Deploy.s.sol/31337/run-latest.json broadcast/Other.s.sol/1/run-latest.json
+
+  export GITHUB_OUTPUT="$TMPDIR/github-output.txt"
+  touch "$GITHUB_OUTPUT"
+
+  if bash "$SCRIPT_DIR/scripts/deploy/parse-broadcast.sh" > /dev/null 2>&1; then
+    echo "FAIL: should have exited with error on ambiguous broadcasts"
+    exit 1
+  fi
+
+  echo "PASS: fails on ambiguous broadcast files"
+) || { FAILURES=$((FAILURES + 1)); }
+
+# Test 5: DEPLOY_SCRIPT scopes the search when multiple broadcasts exist
+(
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
+  cp -r "$SCRIPT_DIR/tests/fixtures/broadcast" "$TMPDIR/"
+  cd "$TMPDIR"
+  mkdir -p broadcast/Other.s.sol/1
+  cp broadcast/Deploy.s.sol/31337/run-latest.json broadcast/Other.s.sol/1/run-latest.json
+
+  export GITHUB_OUTPUT="$TMPDIR/github-output.txt"
+  export DEPLOY_SCRIPT="script/Deploy.s.sol:Deploy"
+  touch "$GITHUB_OUTPUT"
+
+  bash "$SCRIPT_DIR/scripts/deploy/parse-broadcast.sh" > /dev/null
+
+  grep -q "broadcast_file=broadcast/Deploy.s.sol/31337/run-latest.json" "$GITHUB_OUTPUT" \
+    || { echo "FAIL: DEPLOY_SCRIPT did not scope the search"; cat "$GITHUB_OUTPUT"; exit 1; }
+
+  echo "PASS: DEPLOY_SCRIPT scopes the broadcast search"
+) || { FAILURES=$((FAILURES + 1)); }
+
+echo "--- $((5 - FAILURES))/5 tests passed ---"
 exit $FAILURES

--- a/tests/test-write-deployment-json.sh
+++ b/tests/test-write-deployment-json.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+FAILURES=0
+
+echo "=== Testing scripts/deploy/write-deployment-json.sh ==="
+
+# Test 1: Writes deployment.json with CREATE and CREATE2 contracts
+(
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
+  cp -r "$SCRIPT_DIR/tests/fixtures/broadcast" "$TMPDIR/"
+  cd "$TMPDIR"
+
+  export BROADCAST_FILE="broadcast/Deploy.s.sol/31337/run-latest.json"
+  export NETWORK_NAME="sepolia"
+
+  bash "$SCRIPT_DIR/scripts/deploy/write-deployment-json.sh" > /dev/null
+
+  [[ -f deployments/sepolia/deployment.json ]] || { echo "FAIL: deployment.json not created"; exit 1; }
+
+  COUNT=$(jq '.contracts | length' deployments/sepolia/deployment.json)
+  [[ "$COUNT" -eq 3 ]] || { echo "FAIL: expected 3 contracts, got $COUNT"; exit 1; }
+
+  jq -e '.contracts[] | select(.sourcePathAndName == "src/MyToken.sol:MyToken" and .address == "0x1234567890abcdef1234567890abcdef12345678")' \
+    deployments/sepolia/deployment.json > /dev/null || { echo "FAIL: MyToken entry wrong"; exit 1; }
+  jq -e '.contracts[] | select(.sourcePathAndName == "src/MyFactory.sol:MyFactory")' \
+    deployments/sepolia/deployment.json > /dev/null || { echo "FAIL: CREATE2 contract missing"; exit 1; }
+
+  echo "PASS: writes deployment.json with CREATE and CREATE2 entries"
+) || { FAILURES=$((FAILURES + 1)); }
+
+# Test 2: Fails when required env vars are missing
+(
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
+  cd "$TMPDIR"
+
+  if BROADCAST_FILE="" NETWORK_NAME="" bash "$SCRIPT_DIR/scripts/deploy/write-deployment-json.sh" > /dev/null 2>&1; then
+    echo "FAIL: should have exited with error"
+    exit 1
+  fi
+
+  echo "PASS: fails when env vars missing"
+) || { FAILURES=$((FAILURES + 1)); }
+
+echo "--- $((2 - FAILURES))/2 tests passed ---"
+exit $FAILURES


### PR DESCRIPTION
Addresses the full codebase improvement review: two user-facing bugs, the structural dedup refactor, a supply-chain/injection hardening pass, robustness fixes, missing features from the spec, and self-testing CI.

## Bug fixes

- **The documented minimum setup no longer fails.** `_foundry-cicd.yml`'s upgrade-safety job hard-errored for any consumer without `.github/upgrades.json` (and blocked `deploy-on-pr` with it). It is now skipped when the config file is absent, and the deploy gate accepts a skipped upgrade-safety job. The standalone `_upgrade-safety.yml` keeps the hard error, since calling it is an explicit opt-in.
- **CREATE2 deployments are no longer silently dropped** from the address summary, `deployment.json`, and Blockscout verification. Unnamed nested deployments (`additionalContracts`) are reported as a warning instead of vanishing.

## Structure

- New composite action `.github/actions/setup` replaces nine copies of the checkout/Foundry/Node/install preamble and adds Foundry compile caching. Jobs get it via the existing sparse checkout of etherform, pinned to `job.workflow_sha` — so the scripts, setup action, and workflow are always the same commit (fixes the `etherform-ref` split-brain pitfall; the input remains as an override).
- `_foundry-cicd.yml` is now a thin orchestrator (581 → 290 lines) calling `_ci.yml`, `_upgrade-safety.yml`, and `_deploy-testnet.yml` as nested reusable workflows. The behavioral drift between the copies is resolved by unifying on: chain-id-based network resolution, `deployment.json` artifact output, and passing `--private-key` (all previously inconsistent between `_foundry-cicd.yml` and `_deploy-testnet.yml`).

## Hardening

- All actions pinned to full commit SHAs (checkout v5.0.1, setup-node v6.4.0, foundry-toolchain v1.8.0, paths-filter v4.0.2, sticky-comment v2.9.4, slither-action v0.4.2, upload/download-artifact, cache, setup-python).
- Workflow inputs routed through `env:` instead of interpolated into `run:` blocks; `test-verbosity` validated against an allowlist.
- Deploys restricted to same-repo PRs (fork PRs have no secrets and previously failed confusingly) and serialized per ref via job-level concurrency with `cancel-in-progress: false`.
- New version pins/inputs: `foundry-version` (default `stable`), `halmos-version`, `oz-upgrades-core-version`; Node default bumped 20 → 22 (20 is past EOL).
- README now recommends enumerated secrets over `secrets: inherit`, a caller-side `concurrency` block, and pinning the workflow ref.

## Robustness

- `parse-broadcast.sh`: chain id from the artifact's `chain` field (path fallback), `DEPLOY_SCRIPT` scoping, and a hard error on ambiguous multiple broadcasts (was: arbitrary `head -1`).
- `extract-summary.sh`: POSIX-portable parsing — no GNU `grep -P`, so the test suite now passes on macOS — and a regression test for the forge ≥ 1.7 table format.
- `validate.sh`: installs the OZ CLI once instead of `npx` resolution per contract; supports per-contract `"options": ["--unsafeAllowRenames"]` passthrough.
- Deployment artifact logic extracted to `write-deployment-json.sh` with unit tests.

## Features

- **Mainnet deploys under protected GitHub Environments** (the missing piece from the spec): `_deploy-testnet.yml` gains an `environment` input; README Step 6 documents the on-merge mainnet pattern.
- `working-directory` input on `_ci.yml`/`_foundry-cicd.yml` for monorepos (upgrade safety and deploy still assume repo root — documented).

## Testing

- New `e2e.yml` runs the real `_foundry-cicd.yml` against a dependency-free fixture Foundry project (`tests/fixtures/project`) on every PR: change detection, nested `_ci.yml` (fmt/build/test), coverage extraction + 90% threshold, and the graceful upgrade-safety skip. This would have caught the missing-`upgrades.json` bug.
- `test.yml` adds actionlint, extends ShellCheck to `tests/`, and auto-discovers test files.
- Verified locally: all 37 unit tests pass (on macOS, proving the portability fix), `shellcheck` clean, `actionlint` clean, and the fixture project passes `forge fmt --check`, `forge test`, and `forge coverage` (100%) on forge 1.7.1.

## Breaking changes for consumers

- `_foundry-cicd.yml`: `main-branch` renamed to `base-branch` (now consistent with `_upgrade-safety.yml`).
- `_deploy-testnet.yml`: `network-index` removed — the network is resolved from the deployed chain ID; the deploy job is named `Deploy Contracts` (was `Deploy to Testnet`).
- Nested orchestration changes check names (e.g. `CI/CD / ci / Build & Test`) — **required status checks in consumer branch-protection rules need updating**.
- Coverage sticky comment now uses an explicit `header: coverage`, so the first run on an existing PR posts a fresh comment.
- Deploy in `_foundry-cicd.yml` is now gated on the whole CI workflow (including Slither/Halmos when enabled), not just Build & Test — stricter, intentional.

## Things to watch on first downstream run

- The e2e workflow validates nested `./` workflow calls and `job.workflow_sha` when caller and callee are the same repo; the cross-repo case (a consumer calling `@main`) can't be exercised from this repo's CI, so a smoke test on one downstream repo after merge is recommended.
- The `empty-environment-guard` job in e2e pins the assumption that `environment: ''` means "no environment"; if GitHub changes that, e2e goes red here rather than in consumers.