### PR TITLE
fix(deploy): make Blockscout verification work without an RPC and bound its runtime

### DIFF
--- a/scripts/deploy/verify-blockscout.sh
+++ b/scripts/deploy/verify-blockscout.sh
@@ -4,12 +4,20 @@ set -euo pipefail
 # Phase 1: Submit all contracts for verification
 # Phase 2: Poll Blockscout API for verification status with retries
 #
+# Constructor args are derived offline from the broadcast file (creation tx
+# input minus the compiled creation bytecode), so no RPC access is needed —
+# `--guess-constructor-args` hard-fails without one, which silently broke
+# every submission for callers that don't export ETH_RPC_URL.
+#
 # Env inputs:
 #   BLOCKSCOUT_URL  — required
 #   BROADCAST_FILE  — required, path to run-latest.json
-#   MAX_CHECKS      — optional, default 10
-#   CHECK_DELAY     — optional, default 30 (seconds between checks)
+#   MAX_CHECKS      — optional, default 10 (status-poll rounds across ALL contracts)
+#   CHECK_DELAY     — optional, default 30 (seconds between poll rounds)
 #   INITIAL_WAIT    — optional, default 60 (seconds to wait after submission)
+#
+# Worst-case runtime is bounded by INITIAL_WAIT + MAX_CHECKS * CHECK_DELAY
+# (plus submission time), independent of the number of contracts.
 
 : "${BLOCKSCOUT_URL:?BLOCKSCOUT_URL is required}"
 : "${BROADCAST_FILE:?BROADCAST_FILE is required}"
@@ -29,6 +37,19 @@ fi
 
 # Normalize URL once (strip trailing slash) to avoid double-slash in API calls
 BLOCKSCOUT_URL="${BLOCKSCOUT_URL%/}"
+
+# Some Blockscout deployments 301 to a canonical host (e.g.
+# optimism.blockscout.com → explorer.optimism.io). forge's verification POSTs
+# don't survive that redirect (re-issued as GET, dropping the payload), so
+# resolve the final host up front and use it everywhere.
+EFFECTIVE_URL=$(curl -sL -o /dev/null -w '%{url_effective}' --connect-timeout 10 --max-time 30 "${BLOCKSCOUT_URL}/api?module=stats&action=ethsupply" 2>/dev/null) || EFFECTIVE_URL=""
+if [[ "$EFFECTIVE_URL" =~ ^(https?://[^/]+) ]]; then
+  EFFECTIVE_HOST="${BASH_REMATCH[1]}"
+  if [[ "$EFFECTIVE_HOST" != "$BLOCKSCOUT_URL" ]]; then
+    echo "Blockscout redirects to ${EFFECTIVE_HOST} — using it for verification"
+    BLOCKSCOUT_URL="$EFFECTIVE_HOST"
+  fi
+fi
 
 # Collect all named CREATE/CREATE2 contracts. Nested deployments
 # (additionalContracts) have no contract name in the broadcast artifact and
@@ -53,12 +74,37 @@ fi
 for entry in "${CONTRACTS[@]}"; do
   CONTRACT_NAME="${entry%%:*}"
   CONTRACT_ADDR="${entry#*:}"
+
+  # Constructor args = creation tx input minus the compiled creation bytecode
+  # (same build, so the artifact is an exact prefix). If the prefix doesn't
+  # match (e.g. library placeholders), omit the flag — Blockscout can extract
+  # the args from the creation tx on its own.
+  ARGS_FLAG=()
+  TX_INPUT=$(jq -r --arg addr "$CONTRACT_ADDR" '[.transactions[]
+    | select(.contractAddress == $addr)
+    | .transaction.input][0] // ""' "$BROADCAST_FILE")
+  CREATION_CODE=$(forge inspect "$CONTRACT_NAME" bytecode 2>/dev/null) || CREATION_CODE=""
+  if [[ -n "$CREATION_CODE" && "$TX_INPUT" == "$CREATION_CODE"* && "$TX_INPUT" != "$CREATION_CODE" ]]; then
+    ARGS_FLAG=(--constructor-args "0x${TX_INPUT#"$CREATION_CODE"}")
+  fi
+
+  # A bare contract name carries no compiler version — read it from the build
+  # artifact, or forge errors with "Compiler version has to be set".
+  VERSION_FLAG=()
+  COMPILER_VERSION=$(forge inspect "$CONTRACT_NAME" metadata 2>/dev/null | jq -r '.compiler.version // ""') || COMPILER_VERSION=""
+  if [[ -n "$COMPILER_VERSION" ]]; then
+    VERSION_FLAG=(--compiler-version "$COMPILER_VERSION")
+  fi
+
   echo "Submitting $CONTRACT_NAME ($CONTRACT_ADDR) for verification..."
   SUBMIT_OUTPUT=$(forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
     --verifier blockscout \
     --verifier-url "${BLOCKSCOUT_URL}/api" \
-    --guess-constructor-args 2>&1) || true
-  echo "$SUBMIT_OUTPUT"
+    "${VERSION_FLAG[@]}" \
+    "${ARGS_FLAG[@]}" 2>&1) || true
+  # Some Blockscout instances echo the full standard-json back — truncate to
+  # keep logs readable.
+  echo "${SUBMIT_OUTPUT:0:400}"
   if echo "$SUBMIT_OUTPUT" | grep -qi "already verified"; then
     echo "  -> already verified"
   fi
@@ -68,43 +114,47 @@ done
 echo "Waiting ${INITIAL_WAIT}s for Blockscout to process submissions..."
 sleep "$INITIAL_WAIT"
 
-# Phase 3: Check verification status via API, retry unverified contracts
-VERIFY_FAILED=0
+# Phase 3: Poll verification status via API in rounds across ALL pending
+# contracts (a per-contract retry loop would take up to
+# MAX_CHECKS * CHECK_DELAY seconds PER CONTRACT and blow any step timeout).
+PENDING=("${CONTRACTS[@]}")
 
-for entry in "${CONTRACTS[@]}"; do
-  CONTRACT_NAME="${entry%%:*}"
-  CONTRACT_ADDR="${entry#*:}"
+for check in $(seq 1 "$MAX_CHECKS"); do
+  STILL_PENDING=()
+  for entry in "${PENDING[@]}"; do
+    CONTRACT_NAME="${entry%%:*}"
+    CONTRACT_ADDR="${entry#*:}"
 
-  VERIFIED=0
-  for check in $(seq 1 "$MAX_CHECKS"); do
-    # Query Blockscout API for verification status
-    API_RESULT=$(curl -sf --connect-timeout 10 --max-time 30 "${BLOCKSCOUT_URL}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
+    # Query Blockscout API for verification status. -L: some instances 301 to
+    # a canonical host (e.g. optimism.blockscout.com → explorer.optimism.io).
+    API_RESULT=$(curl -sfL --connect-timeout 10 --max-time 30 "${BLOCKSCOUT_URL}/api?module=contract&action=getabi&address=${CONTRACT_ADDR}" 2>/dev/null) || true
     API_STATUS=$(echo "$API_RESULT" | jq -r '.status // "0"' 2>/dev/null) || API_STATUS="0"
 
     if [[ "$API_STATUS" == "1" ]]; then
       echo "Verified: $CONTRACT_NAME ($CONTRACT_ADDR)"
-      VERIFIED=1
-      break
-    fi
-
-    if [[ $check -lt $MAX_CHECKS ]]; then
-      echo "  $CONTRACT_NAME not yet verified (check $check/$MAX_CHECKS), resubmitting and waiting ${CHECK_DELAY}s..."
-      # Resubmit to ensure it's in the queue
-      forge verify-contract "$CONTRACT_ADDR" "$CONTRACT_NAME" \
-        --verifier blockscout \
-        --verifier-url "${BLOCKSCOUT_URL}/api" \
-        --guess-constructor-args 2>&1 || true
-      sleep "$CHECK_DELAY"
+    else
+      STILL_PENDING+=("$entry")
     fi
   done
 
-  if [[ $VERIFIED -eq 0 ]]; then
-    echo "::error::Verification failed for $CONTRACT_NAME ($CONTRACT_ADDR) after $MAX_CHECKS checks"
-    VERIFY_FAILED=1
+  PENDING=()
+  if [[ ${#STILL_PENDING[@]} -gt 0 ]]; then
+    PENDING=("${STILL_PENDING[@]}")
+  fi
+
+  if [[ ${#PENDING[@]} -eq 0 ]]; then
+    break
+  fi
+  if [[ $check -lt $MAX_CHECKS ]]; then
+    echo "  ${#PENDING[@]} contract(s) not yet verified (check $check/$MAX_CHECKS), waiting ${CHECK_DELAY}s..."
+    sleep "$CHECK_DELAY"
   fi
 done
 
-if [[ $VERIFY_FAILED -eq 1 ]]; then
+if [[ ${#PENDING[@]} -gt 0 ]]; then
+  for entry in "${PENDING[@]}"; do
+    echo "::error::Verification failed for ${entry%%:*} (${entry#*:}) after $MAX_CHECKS checks"
+  done
   echo "::error::One or more contracts failed verification"
   exit 1
 fi


### PR DESCRIPTION
## Problem

`verify-blockscout.sh` has never successfully verified anything for consumers that don't export `ETH_RPC_URL` (e.g. crowdstake.fun's deploy workflow, which exports `RPC_URL` — a variable forge doesn't read), and its retry loop is effectively unbounded:

1. **Every submission silently failed**: `--guess-constructor-args` hard-errors with `You have to provide a valid RPC URL to use --guess-constructor-args feature` when no RPC is configured. The `|| true` swallowed it, so Phase 1 submitted nothing.
2. **Phase 3 then hangs**: the per-contract retry loop is up to `MAX_CHECKS × CHECK_DELAY` = 300 s **per contract**. A 20-contract deploy has a ~100-minute worst case — the first contract alone blows a 5-minute step timeout, so the step gets killed before anything verifies. This is exactly what happened on crowdstake.fun runs 29133058331 / 29133083853 / 29133084514 (2026-07-11): `The action 'Verify on Blockscout' has timed out after 5 minutes` on every run, zero contracts verified.
3. Two latent bugs surfaced once (1) was fixed:
   - bare contract names carry no compiler version → forge errors with *"Compiler version has to be set in foundry.toml"*;
   - some Blockscout deployments 301 to a canonical host (optimism.blockscout.com → explorer.optimism.io); forge's verification POST doesn't survive the redirect (re-issued as GET, payload dropped), and `curl -sf` status checks fail on the 301.

## Fix (interface unchanged: `BLOCKSCOUT_URL`, `BROADCAST_FILE`, `MAX_CHECKS`, `CHECK_DELAY`, `INITIAL_WAIT`)

- Derive constructor args **offline from the broadcast file**: creation tx `input` minus the compiled creation bytecode (`forge inspect <name> bytecode`). No RPC needed at all. Falls back to letting Blockscout extract args from the creation tx if the prefix doesn't match (e.g. library placeholders).
- Pass `--compiler-version` from the build artifact metadata (`forge inspect <name> metadata`).
- Resolve the canonical Blockscout host up front (follow the redirect once) and add `-L` to the status-poll curl.
- Poll verification status **in rounds across all pending contracts**: worst case is now `INITIAL_WAIT + MAX_CHECKS × CHECK_DELAY` regardless of contract count, with early exit when everything is verified. Dropped the blind resubmit-on-every-check.
- Truncate echoed submission responses (some instances echo the full standard-json back — megabytes per contract in the logs).

## Validation

Ran the fixed script end-to-end against the 2026-07-11 crowdstake.fun `DeployCrowdStakeDeployer` broadcasts: all 20 broadcast contracts verified with exit 0 on each of:
- Gnosis (`https://gnosis.blockscout.com`)
- Arbitrum (`https://arbitrum.blockscout.com`)
- Optimism (`https://optimism.blockscout.com` → auto-resolved to `explorer.optimism.io`)

including the redirect-host path and the constructor-args derivation for contracts with 1, 2, and 10 constructor arguments.

Note for consumers: `_deploy-testnet.yml` keeps working unchanged (it exported `ETH_RPC_URL`, which is simply no longer needed). Callers with tight step timeouts can now tune `INITIAL_WAIT`/`CHECK_DELAY`/`MAX_CHECKS` to a hard bound.